### PR TITLE
Add concurrent engine to studio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+bin
+target
+build.acceleo
+.metadata
+*._trace
+**/gemoc-gen/*
+**/xtend-gen/*
+node_modules
+/package-lock.json
+**/.polyglot.build.properties

--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+-------------
+This repository is part of a serie of repositories related to [GEMOC Studio](http://eclipse.org/gemoc) :
+- https://github.com/eclipse/gemoc-studio
+- https://github.com/eclipse/gemoc-studio-modeldebugging
+- https://github.com/eclipse/gemoc-studio-execution-ale
+- https://github.com/eclipse/gemoc-studio-execution-java
+- https://github.com/eclipse/gemoc-studio-execution-moccml
+- https://github.com/eclipse/gemoc-studio-moccml
+-------------
+
+
+
+MOCCML engine for GEMOC
+====================
+
+The MoCCML / Concurrency provides components and engines supporting concurrency and/or time in execution semantics. 
+
+# Development
+- Continuous integration on [Eclipse CI](https://ci.eclipse.org/gemoc/job/gemoc-studio/)
+- [Instructions for building](https://github.com/eclipse/gemoc-studio/tree/master/dev_support/full_compilation)

--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,12 @@
     <artifactId>org.eclipse.gemoc.execution.concurrent.ccsljava.root</artifactId>
     <version>2.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>    
-	<parent>
-		<groupId>org.eclipse.gemoc</groupId>
-		<artifactId>org.eclipse.gemoc.concurrent.root</artifactId>
-    	<version>2.3.0-SNAPSHOT</version>
-		<relativePath>..</relativePath>
-	</parent>
+    <properties>
+		<tycho-version>1.2.0</tycho-version>
+    	<xtend.version>2.14.0</xtend.version>
+		<project.build.sourceEncoding>UTF8</project.build.sourceEncoding>
+		<tycho.scmUrl>scm:git:https://github.com/gemoc/concurrency.git</tycho.scmUrl>
+	</properties>
     <modules>
     
         <!-- plugins -->
@@ -40,6 +40,287 @@
 <!--         <module>ccsljava_xdsml/tests/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.tests</module> -->
 
     </modules>
+  	<repositories>
 
+  	<!-- List of P2 repositories of external tool used to build the components -->
+  	<!--  must NOT include the repositories of the tools included in the Studio has it has its own complementary list -->
+        <repository>
+            <id>Photon release</id>
+            <layout>p2</layout>
+            <url>http://download.eclipse.org/releases/photon/</url>
+        </repository>
+        <repository>
+            <id>timesquare</id>
+            <layout>p2</layout>
+            <url>http://www.i3s.unice.fr/~deantoni/photon/</url>
+<!--             <url>http://timesquare.inria.fr/update_site/photon</url> -->
+        </repository>
+		<repository>
+            <id>kermeta-3</id>
+            <layout>p2</layout>
+            <url>http://www.kermeta.org/k3/update_2018-09-05</url>
+        </repository>
+        <repository>
+            <id>melange</id>
+            <layout>p2</layout>
+            <url>http://melange.inria.fr/updatesite/nightly/update_2019-01-25/</url>
+        </repository>
+        <repository>
+            <id>Sirius</id>
+            <layout>p2</layout>
+            <url>http://download.eclipse.org/sirius/updates/releases/6.0.2/photon</url>
+        </repository>
+        <repository>
+            <id>nebula</id>
+            <layout>p2</layout>
+            <url>http://archive.eclipse.org/nebula/Q22016/incubation</url>
+        </repository>
+ <!--        <repository>
+            <id>gemoc_non_concurrent</id>
+            <layout>p2</layout>
+            <url>http://download.eclipse.org/gemoc/updates/nightly/</url>
+        </repository> -->
+        
+        <repository> <!-- indirectly, required by the test that indirectly grabs sequential_addon.stategraph that depends on it -->
+            <id>elk</id>
+            <layout>p2</layout>
+            <url>http://download.eclipse.org/elk/updates/releases/0.1.0/</url>
+        </repository>
+		<repository> <!-- used in some tests -->
+            <id>Groovy4Eclipse</id>
+            <layout>p2</layout>
+            <url>http://dist.springsource.org/snapshot/GRECLIPSE/e4.6/</url>
+        </repository>
+        
+        <repository> <!-- used in some tests -->
+            <id>AspectJ</id>
+            <layout>p2</layout>
+            <url>http://download.eclipse.org/tools/ajdt/46/dev/update</url>
+        </repository>
+        <repository> <!-- this repo is used to provide jdom and jaxen plugins -->
+            <id>app4mc</id>
+            <layout>p2</layout>
+            <url>http://download.eclipse.org/app4mc/updatesites/releases/0.8.0/</url>
+        </repository>
+    </repositories>
+
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-maven-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<extensions>true</extensions>
+			</plugin>
+			<!-- enable source bundle generation -->
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-source-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<executions>
+					<execution>
+						<id>plugin-source</id>
+						<goals>
+							<goal>plugin-source</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<!-- enable source feature generation -->
+			<plugin>
+		      <groupId>org.eclipse.tycho.extras</groupId>
+		      <artifactId>tycho-source-feature-plugin</artifactId>
+		      <version>${tycho-version}</version>
+		      <executions>
+		        <execution>
+		          <id>source-feature</id>
+		          <phase>package</phase>
+		          <goals>
+		            <goal>source-feature</goal>
+		          </goals>
+		        </execution>
+		      </executions>
+		    </plugin>
+		    <plugin>
+		     <groupId>org.eclipse.tycho</groupId>
+		     <artifactId>tycho-p2-plugin</artifactId>
+		     <version>${tycho-version}</version>
+		     <executions>
+		       <execution>
+		         <id>attach-p2-metadata</id>
+		         <phase>package</phase>
+		         <goals>
+		           <goal>p2-metadata</goal>
+		         </goals>
+		       </execution>
+		     </executions>
+		    </plugin>
+		    <!-- enable generation of Eclipse-SourceReferences MANIFEST header -->
+		    <plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-packaging-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<dependencies>
+					<dependency>
+       					<groupId>org.eclipse.tycho.extras</groupId>
+			        	<artifactId>tycho-sourceref-jgit</artifactId>
+			        	<version>${tycho-version}</version>
+			      	</dependency>
+				</dependencies>
+				<configuration>
+					<sourceReferences>
+       					<generate>true</generate>
+     				</sourceReferences>
+				</configuration>
+			</plugin>
+			<!--<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-p2-director-plugin</artifactId>
+				<version>${tycho-version}</version>
+				<executions>
+					<execution>
+						<id>materialize-products</id>
+						<goals>
+							<goal>materialize-products</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>archive-products</id>
+						<goals>
+							<goal>archive-products</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>-->
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho-version}</version>
+				<configuration>
+					<!-- environments that will be built -->
+					<environments>
+						<environment>
+							<os>linux</os>
+							<ws>gtk</ws>
+							<arch>x86_64</arch>
+						</environment>
+						<environment>
+							<os>win32</os>
+							<ws>win32</ws>
+							<arch>x86_64</arch>
+						</environment>
+						<environment>
+							<os>macosx</os>
+							<ws>cocoa</ws>
+							<arch>x86_64</arch>
+						</environment>
+					</environments>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.xtend</groupId>
+				<artifactId>xtend-maven-plugin</artifactId>
+				<version>${xtend.version}</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>compile</goal>
+							<goal>xtend-install-debug-info</goal>
+							<goal>testCompile</goal>
+							<goal>xtend-test-install-debug-info</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>xtend-gen</outputDirectory>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+            <!-- Java compiler plugin -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.8.0</version>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+					<encoding>${project.build.sourceEncoding}</encoding>
+                                        <artifact>
+                                            <id>org.jdom:jdom2:2.0.6</id>
+                                            <source>true</source>
+                                            <instructions>
+                                                <Bundle-SymbolicName>org.jdom2</Bundle-SymbolicName>
+                                            </instructions>
+                                        </artifact>
+				</configuration>
+			</plugin>
+		</plugins>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<version>3.8.0</version>
+					<configuration>
+						<source>1.8</source>
+						<target>1.8</target>
+						<encoding>${project.build.sourceEncoding}</encoding>
+					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.eclipse.xtend</groupId>
+					<artifactId>xtend-maven-plugin</artifactId>
+					<version>${xtend.version}</version>
+					<executions>
+						<execution>
+							<goals>
+								<goal>compile</goal>
+								<goal>xtend-install-debug-info</goal>
+								<goal>testCompile</goal>
+								<goal>xtend-test-install-debug-info</goal>
+							</goals>
+							<configuration>
+								<outputDirectory>xtend-gen</outputDirectory>
+							</configuration>
+						</execution>
+					</executions>
+					<!-- workaround https://github.com/eclipse/xtext/issues/1231 -->
+					<!-- workaround https://github.com/eclipse/xtext/issues/1373 -->
+					<!-- Remove with upgrade to Xtext 2.15 -->
+					<dependencies>
+						<dependency>
+							<groupId>org.eclipse.jdt</groupId>
+							<artifactId>org.eclipse.jdt.core</artifactId>
+							<version>3.13.102</version>
+						</dependency>
+						<dependency>
+							<groupId>org.eclipse.jdt</groupId>
+							<artifactId>org.eclipse.jdt.compiler.apt</artifactId>
+							<version>1.3.110</version>
+						</dependency>
+						<dependency>
+							<groupId>org.eclipse.jdt</groupId>
+							<artifactId>org.eclipse.jdt.compiler.tool</artifactId>
+							<version>1.2.101</version>
+						</dependency>
+						<dependency>
+							<groupId>org.eclipse.emf</groupId>
+							<artifactId>org.eclipse.emf.codegen</artifactId>
+							<version>2.11.0</version>
+						</dependency>
+					</dependencies>
+				</plugin>
+				<plugin>
+					<artifactId>maven-clean-plugin</artifactId>
+		    		<version>3.1.0</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-antrun-plugin</artifactId>
+					<version>1.8</version>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
  
 </project>


### PR DESCRIPTION
This PR adds the build support and deployment of the concurrent engine in the studio.

cf. https://github.com/eclipse/gemoc-studio/issues/146
It comes with several PR in other repositories:
* https://github.com/eclipse/gemoc-studio-moccml/pull/1
* https://github.com/eclipse/gemoc-studio-execution-ale/pull/8
* https://github.com/eclipse/gemoc-studio-modeldebugging/pull/98
* https://github.com/eclipse/gemoc-studio/pull/148