### PR TITLE
Renaming of MelangeXDSMLHelper into XDSMLHelper

### DIFF
--- a/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.ui/src/main/java/org/eclipse/gemoc/execution/concurrent/ccsljavaxdsml/ui/wizards/CreateDSEWizardContextAction.java
+++ b/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.ui/src/main/java/org/eclipse/gemoc/execution/concurrent/ccsljavaxdsml/ui/wizards/CreateDSEWizardContextAction.java
@@ -18,7 +18,7 @@ import org.eclipse.gemoc.commons.eclipse.core.resources.NewProjectWorkspaceListe
 import org.eclipse.gemoc.commons.eclipse.ui.WizardFinder;
 import org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.ui.Activator;
 import org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.ui.dialogs.SelectECLIFileDialog;
-import org.eclipse.gemoc.xdsmlframework.ide.ui.xdsml.wizards.MelangeXDSMLProjectHelper;
+import org.eclipse.gemoc.xdsmlframework.ui.utils.XDSMLProjectHelper;
 import org.eclipse.jface.wizard.WizardDialog;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchWizard;
@@ -115,7 +115,7 @@ public class CreateDSEWizardContextAction {
 	}
 
 	protected void initWizardFromMelangeLanguage(CreateNewDSEProject createNewDSEProjectWizard, String language){
-		createNewDSEProjectWizard._askProjectNamePage.setInitialProjectName(MelangeXDSMLProjectHelper.baseProjectName(gemocLanguageIProject)+".dse");
+		createNewDSEProjectWizard._askProjectNamePage.setInitialProjectName(XDSMLProjectHelper.baseProjectName(gemocLanguageIProject)+".dse");
 		createNewDSEProjectWizard._askDSEInfoPage.initialTemplateECLFileFieldValue = language;
 //		createNewDSEProjectWizard._askDSEInfoPage.initialEcoreFileFieldValue =  "platform:/resource"+MelangeXDSMLProjectHelper.getFirstEcorePath(language);
 		// FIXME currently we do not know how to store the DefaultRootContainer in a melangeXDSML project 

--- a/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.ui/src/main/java/org/eclipse/gemoc/execution/concurrent/ccsljavaxdsml/ui/wizards/CreateMOCCWizardContextAction.java
+++ b/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.ui/src/main/java/org/eclipse/gemoc/execution/concurrent/ccsljavaxdsml/ui/wizards/CreateMOCCWizardContextAction.java
@@ -16,7 +16,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.gemoc.commons.eclipse.core.resources.NewProjectWorkspaceListener;
 import org.eclipse.gemoc.commons.eclipse.ui.WizardFinder;
 import org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.ui.Activator;
-import org.eclipse.gemoc.xdsmlframework.ide.ui.xdsml.wizards.MelangeXDSMLProjectHelper;
+import org.eclipse.gemoc.xdsmlframework.ui.utils.XDSMLProjectHelper;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.wizard.WizardDialog;
 import org.eclipse.ui.IWorkbench;
@@ -106,7 +106,7 @@ public class CreateMOCCWizardContextAction {
 	}
 	
 	protected void initWizardFromLanguage(CreateNewMoCProject createNewMOCProjectWizard, String language){
-		createNewMOCProjectWizard._askProjectNamePage.setInitialProjectName(MelangeXDSMLProjectHelper.baseProjectName(gemocLanguageIProject)+".mocc");
+		createNewMOCProjectWizard._askProjectNamePage.setInitialProjectName(XDSMLProjectHelper.baseProjectName(gemocLanguageIProject)+".mocc");
 		createNewMOCProjectWizard._askMoCInfoPage.initialTemplateMoCFileFieldValue = language.replaceAll(" ", "_");
 	}
 	

--- a/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.ui/src/main/java/org/eclipse/gemoc/execution/concurrent/ccsljavaxdsml/ui/wizards/contextDSA/CreateDSAWizardContextActionDSAK3.java
+++ b/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.ui/src/main/java/org/eclipse/gemoc/execution/concurrent/ccsljavaxdsml/ui/wizards/contextDSA/CreateDSAWizardContextActionDSAK3.java
@@ -20,7 +20,7 @@ import org.eclipse.gemoc.commons.eclipse.ui.WizardFinder;
 import org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.ui.Activator;
 import org.eclipse.gemoc.executionframework.ui.xdsml.activefile.ActiveFile;
 import org.eclipse.gemoc.executionframework.ui.xdsml.activefile.ActiveFileEcore;
-import org.eclipse.gemoc.xdsmlframework.ide.ui.xdsml.wizards.MelangeXDSMLProjectHelper;
+import org.eclipse.gemoc.xdsmlframework.ui.utils.XDSMLProjectHelper;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.wizard.IWizard;
 import org.eclipse.jface.wizard.WizardDialog;
@@ -71,7 +71,7 @@ public class CreateDSAWizardContextActionDSAK3 extends CreateDSAWizardContextBas
 				
 				wd.create();
 
-				k3Wizard.getPageProject().setProjectName(MelangeXDSMLProjectHelper.baseProjectName(_gemocLanguageIProject)+".k3dsa");
+				k3Wizard.getPageProject().setProjectName(XDSMLProjectHelper.baseProjectName(_gemocLanguageIProject)+".k3dsa");
 				k3Wizard.getPageProject().setProjectKind(KindsOfProject.PLUGIN);
 				// set field as much as possible
 				


### PR DESCRIPTION
complement to https://github.com/eclipse/gemoc-studio-modeldebugging/pull/104

in particular it contains the renaming of the MelangeXDSMLProjectHelper into XDSMLProjectHelper


Signed-off-by: Didier Vojtisek <didier.vojtisek@inria.fr>