### PR TITLE
Clarifies Eclipse consoles used by the engines

### DIFF
--- a/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.extensions.k3/src/main/java/org/eclipse/gemoc/execution/concurrent/ccsljavaengine/extensions/k3/Activator.java
+++ b/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.extensions.k3/src/main/java/org/eclipse/gemoc/execution/concurrent/ccsljavaengine/extensions/k3/Activator.java
@@ -33,7 +33,9 @@ public class Activator implements BundleActivator {
 		if (messagingSystem == null) 
 		{
 			MessagingSystemManager msm = new MessagingSystemManager();
-			messagingSystem = msm.createBestPlatformMessagingSystem(PLUGIN_ID, "GEMOC extensions k3");
+			messagingSystem = msm.createBestPlatformMessagingSystem(
+					org.eclipse.gemoc.executionframework.engine.Activator.PLUGIN_ID, 
+					org.eclipse.gemoc.executionframework.engine.Activator.CONSOLE_NAME);
 		}
 		return messagingSystem;
 	}

--- a/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.extensions.timesquare/src/main/java/org/eclipse/gemoc/execution/concurrent/ccsljavaengine/extensions/timesquare/Activator.java
+++ b/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.extensions.timesquare/src/main/java/org/eclipse/gemoc/execution/concurrent/ccsljavaengine/extensions/timesquare/Activator.java
@@ -73,7 +73,9 @@ public class Activator extends GemocPlugin {
 			_loggingBackend = new DefaultLoggingBackend(this);
 			MessagingSystemManager msm = new MessagingSystemManager();
 			// use the baseMessageGroup of the engine in order to share consoles instead of duplicating them
-			MessagingSystem ms = msm.createBestPlatformMessagingSystem(org.eclipse.gemoc.executionframework.engine.Activator.PLUGIN_ID, "Modeling Workbench Console");
+			MessagingSystem ms = msm.createBestPlatformMessagingSystem(
+					org.eclipse.gemoc.executionframework.engine.Activator.PLUGIN_ID, 
+					org.eclipse.gemoc.executionframework.engine.Activator.CONSOLE_NAME);
 			_loggingBackend.setMessagingSystem(ms);
 		}
 		return _loggingBackend;

--- a/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.ui/src/main/java/org/eclipse/gemoc/execution/concurrent/ccsljavaengine/ui/Activator.java
+++ b/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.ui/src/main/java/org/eclipse/gemoc/execution/concurrent/ccsljavaengine/ui/Activator.java
@@ -103,7 +103,9 @@ public class Activator extends AbstractUIPlugin {
 		if (messaggingSystem ==  null)
 		{
 			MessagingSystemManager msm = new MessagingSystemManager();
-			messaggingSystem  = msm.createBestPlatformMessagingSystem(org.eclipse.gemoc.executionframework.engine.Activator.PLUGIN_ID, "Modeling Workbench Console");
+			messaggingSystem  = msm.createBestPlatformMessagingSystem(
+					org.eclipse.gemoc.executionframework.engine.Activator.PLUGIN_ID, 
+					org.eclipse.gemoc.executionframework.engine.Activator.CONSOLE_NAME);
 		}
 		return messaggingSystem;
 	}

--- a/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine/src/org/eclipse/gemoc/execution/concurrent/ccsljavaengine/Activator.java
+++ b/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine/src/org/eclipse/gemoc/execution/concurrent/ccsljavaengine/Activator.java
@@ -76,7 +76,8 @@ public class Activator extends GemocPlugin {
 			{
 				_loggingBackend = new DefaultLoggingBackend(this);
 				MessagingSystemManager msm = new MessagingSystemManager();
-				MessagingSystem ms = msm.createBestPlatformMessagingSystem(org.eclipse.gemoc.executionframework.engine.Activator.PLUGIN_ID, 
+				MessagingSystem ms = msm.createBestPlatformMessagingSystem(
+						org.eclipse.gemoc.executionframework.engine.Activator.PLUGIN_ID, 
 						org.eclipse.gemoc.executionframework.engine.Activator.CONSOLE_NAME);
 				_loggingBackend.setMessagingSystem(ms);
 			}

--- a/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine/src/org/eclipse/gemoc/execution/concurrent/ccsljavaengine/Activator.java
+++ b/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine/src/org/eclipse/gemoc/execution/concurrent/ccsljavaengine/Activator.java
@@ -76,7 +76,8 @@ public class Activator extends GemocPlugin {
 			{
 				_loggingBackend = new DefaultLoggingBackend(this);
 				MessagingSystemManager msm = new MessagingSystemManager();
-				MessagingSystem ms = msm.createBestPlatformMessagingSystem(org.eclipse.gemoc.executionframework.engine.Activator.PLUGIN_ID, "Execution Engine");
+				MessagingSystem ms = msm.createBestPlatformMessagingSystem(org.eclipse.gemoc.executionframework.engine.Activator.PLUGIN_ID, 
+						org.eclipse.gemoc.executionframework.engine.Activator.CONSOLE_NAME);
 				_loggingBackend.setMessagingSystem(ms);
 			}
 			return _loggingBackend;

--- a/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.utils/src/org/eclipse/gemoc/execution/concurrent/ccsljavaxdsml/utils/ccsl/QvtoTransformationPerformer.java
+++ b/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.utils/src/org/eclipse/gemoc/execution/concurrent/ccsljavaxdsml/utils/ccsl/QvtoTransformationPerformer.java
@@ -42,7 +42,9 @@ public class QvtoTransformationPerformer {
 		if (messagingSystem == null) {
 			MessagingSystemManager msm = new MessagingSystemManager();
 			// use the baseMessageGroup of the engine in order to share consoles instead of duplicating them
-			messagingSystem = msm.createBestPlatformMessagingSystem(org.eclipse.gemoc.executionframework.engine.Activator.PLUGIN_ID, "Modeling Workbench Console");
+			messagingSystem = msm.createBestPlatformMessagingSystem(
+					org.eclipse.gemoc.executionframework.engine.Activator.PLUGIN_ID, 
+					org.eclipse.gemoc.executionframework.engine.Activator.CONSOLE_NAME);
 		}
 		return messagingSystem;
 	}


### PR DESCRIPTION
This PR clarifies the use of various Eclipse consoles used by the engines.

It makes sure to use a unique console for most engines messages.
The name for this console is currently *Modeling Workbench Console*

This PR comes with several other PR: https://github.com/eclipse/gemoc-studio-modeldebugging/pull/116 https://github.com/eclipse/gemoc-studio-execution-ale/pull/20