### PR TITLE
Make EventSchedulingModelExecutionTracingAddon not default

### DIFF
--- a/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine/plugin.xml
+++ b/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine/plugin.xml
@@ -42,7 +42,7 @@
       <Addon
             AddonGroupId="Concurrent.AddonGroup"
             Class="org.eclipse.gemoc.execution.concurrent.ccsljavaengine.eventscheduling.trace.EventSchedulingModelExecutionTracingAddon"
-            Default="true"
+            Default="false"
             Name="MultiBranch Reflective Trace"
             ShortDescription="Trace the execution events. It is able to trace LogicalStep decisions of concurrent engine."
             id="EventSchedulingExecutionTracing.Addon">


### PR DESCRIPTION
Since this addon is Moccml specific at the moment, we should not make it a default addon for all concurrent engines.