### PR TITLE
Fix the triggering of moccml builder

### DIFF
--- a/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.ui/META-INF/MANIFEST.MF
+++ b/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.ui/META-INF/MANIFEST.MF
@@ -59,6 +59,8 @@ Export-Package: org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.ui,
  org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.ui.commands,
  org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.ui.dialogs,
  org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.ui.dse,
+ org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.ui.editor,
+ org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.ui.templates,
  org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.ui.wizards,
  org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.ui.wizards.pages
 Automatic-Module-Name: org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.ui

--- a/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.ui/src/main/java/org/eclipse/gemoc/execution/concurrent/ccsljavaxdsml/ui/builder/MoccmlLanguageProjectBuilder.java
+++ b/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.ui/src/main/java/org/eclipse/gemoc/execution/concurrent/ccsljavaxdsml/ui/builder/MoccmlLanguageProjectBuilder.java
@@ -119,7 +119,7 @@ public class MoccmlLanguageProjectBuilder extends IncrementalProjectBuilder {
 
 	}
 
-	public static final String BUILDER_ID = Activator.PLUGIN_ID + ".MoccmlLanguageProject";
+	public static final String BUILDER_ID = Activator.PLUGIN_ID + ".MoccmlLanguageProjectBuilder";
 
 	/*
 	 * (non-Javadoc)

--- a/examples/moccmlSigPML/language_workbench/org.eclipse.gemoc.example.moccmlsigpml/.project
+++ b/examples/moccmlSigPML/language_workbench/org.eclipse.gemoc.example.moccmlsigpml/.project
@@ -31,7 +31,7 @@
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.ui.MoccmlLanguageProject</name>
+			<name>org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.ui.MoccmlLanguageProjectBuilder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm/.project
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm/.project
@@ -31,7 +31,7 @@
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.ui.MoccmlLanguageProject</name>
+			<name>org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.ui.MoccmlLanguageProjectBuilder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>


### PR DESCRIPTION
This PR fixes the builder id used in the .project
this fixes  the triggering of builder of  moccml languages
