### PR TITLE
Improve RTDAccessor generator

### DIFF
--- a/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.ui/META-INF/MANIFEST.MF
+++ b/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.ui/META-INF/MANIFEST.MF
@@ -48,7 +48,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.jdt.core.manipulation,
  org.eclipse.jdt.launching,
  org.eclipse.gemoc.execution.concurrent.ccsljavaengine;bundle-version="2.3.0",
- org.eclipse.gemoc.xdsmlframework.commons.ui.k3
+ org.eclipse.gemoc.xdsmlframework.commons.ui.k3,
+ fr.inria.diverse.k3.al.annotationprocessor.plugin;bundle-version="3.2.3"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Import-Package: org.eclipse.core.filesystem,

--- a/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.ui/src/main/java/org/eclipse/gemoc/execution/concurrent/ccsljavaxdsml/ui/builder/BuilderTemplates.java
+++ b/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.ui/src/main/java/org/eclipse/gemoc/execution/concurrent/ccsljavaxdsml/ui/builder/BuilderTemplates.java
@@ -96,36 +96,36 @@ public class BuilderTemplates {
 "\n"+
 "public class ${language.name.toupperfirst}RTDAccessor {\n"+
 "${allGettersAndSetters}\n"+
-"public static Object getAspectProperty(EObject eObject, String languageName, String aspectName, String propertyName) {\n" + 
-"			List<Class<?>> aspects = K3DslHelper.getAspectsOn(languageName, eObject.getClass());\n" + 
-"			Class<?> aspect = null;\n" + 
-"			for (Class<?> a : aspects) {\n" + 
-"				try {\n" + 
-"					if (Class.forName(aspectName).isAssignableFrom(a)) {\n" + 
-"						aspect = a;\n" + 
-"					}\n" + 
-"				} catch (ClassNotFoundException e) {\n" + 
-"					e.printStackTrace();\n" + 
+"	public static Object getAspectProperty(EObject eObject, String languageName, String aspectName, String propertyName) {\n" + 
+"		List<Class<?>> aspects = K3DslHelper.getAspectsOn(languageName, eObject.getClass());\n" + 
+"		Class<?> aspect = null;\n" + 
+"		for (Class<?> a : aspects) {\n" + 
+"			try {\n" + 
+"				if (Class.forName(aspectName).isAssignableFrom(a)) {\n" + 
+"					aspect = a;\n" + 
 "				}\n" + 
-"			}\n" + 
-"			if (aspect == null) {\n" + 
-"				return null;\n" + 
-"			}\n" + 
-"			Object res = null;\n" + 
-"			 try {\n" + 
-"				res = aspect.getDeclaredMethod(propertyName, ((fr.inria.diverse.k3.al.annotationprocessor.Aspect)aspect.getAnnotations()[0]).className()).invoke(eObject, eObject);\n" + 
-"				if (res != null) {\n" + 
-"				return res;\n" + 
-"				}else {\n" + 
-"					return null;\n" + 
-"				}\n" + 
-"			} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException\n" + 
-"					| NoSuchMethodException | SecurityException e) {\n" + 
+"			} catch (ClassNotFoundException e) {\n" + 
 "				e.printStackTrace();\n" + 
 "			}\n" + 
-"			\n" + 
-"			 return null;\n" + 
 "		}\n" + 
+"		if (aspect == null) {\n" + 
+"			return null;\n" + 
+"		}\n" + 
+"		Object res = null;\n" + 
+"		 try {\n" + 
+"			res = aspect.getDeclaredMethod(propertyName, ((fr.inria.diverse.k3.al.annotationprocessor.Aspect)aspect.getAnnotations()[0]).className()).invoke(eObject, eObject);\n" + 
+"			if (res != null) {\n" + 
+"				return res;\n" + 
+"			}else {\n" + 
+"				return null;\n" + 
+"			}\n" + 
+"		} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException\n" + 
+"					| NoSuchMethodException | SecurityException e) {\n" + 
+"			e.printStackTrace();\n" + 
+"		}\n" + 
+"\n" + 
+"		return null;\n" + 
+"	}\n" + 
 "	\n" + 
 "	\n" + 
 "	public static boolean setAspectProperty(EObject eObject, String languageName, String aspectName, String propertyName, Object newValue) {\n" + 


### PR DESCRIPTION
This PR improves RTDAccessor getter/setter signature

- It  avoids signature conflict in case of metamodel with inheritance by using the target "aspectized" class instead of EObject as parameter type
- It uses capitalized names for setter and getter

Signed-off-by: Didier Vojtisek <didier.vojtisek@inria.fr>