### PR TITLE
Validation made on the "k3" entry in the dsl file removed from the MOCCML validation

### DIFF
--- a/concurrent_addons/plugins/org.eclipse.gemoc.addon.metaprogramming/META-INF/MANIFEST.MF
+++ b/concurrent_addons/plugins/org.eclipse.gemoc.addon.metaprogramming/META-INF/MANIFEST.MF
@@ -14,4 +14,5 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.14.0",
  org.eclipse.emf.common,
  org.eclipse.ocl.xtext.base,
  org.eclipse.ocl.xtext.completeocl,
- org.eclipse.ocl
+ org.eclipse.ocl,
+ org.eclipse.gemoc.xdsmlframework.extensions.kermeta3;bundle-version="4.0.0"

--- a/concurrent_addons/plugins/org.eclipse.gemoc.addon.metaprogramming/src/org/eclipse/gemoc/addon/metaprogramming/MOCCMLRule.java
+++ b/concurrent_addons/plugins/org.eclipse.gemoc.addon.metaprogramming/src/org/eclipse/gemoc/addon/metaprogramming/MOCCMLRule.java
@@ -123,34 +123,6 @@ public class MOCCMLRule implements IRule{
 			}
 		}
 		
-		if("k3".matches(entry.getKey())) {
-			String aspectsFields = entry.getValue();
-			
-			IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
-			IFile file = root.getFile(new Path(entry.eResource().getURI().toPlatformString(true)));
-			
-			IProject proj = file.getProject();
-			IJavaProject jProj = JavaCore.create(proj);
-			
-			if(jProj == null) {
-				return (new Message("No project dsa in the workspace", Severity.ERROR));
-			}
-			
-			ArrayList<String> aspectsName = new ArrayList<>();
-			
-			for(String s : aspectsFields.split(",")) {
-				aspectsName.add(s);
-			}
-			
-			for(String asp : aspectsName) {
-				try {
-					jProj.findType(asp);
-				} catch (Exception e) {
-					return (new Message("No aspect matching \""+asp+ "\" in the project", Severity.ERROR));
-				}
-			}
-			
-		}
 		return (new Message("", Severity.DEFAULT));
 	}
 

--- a/concurrent_addons/plugins/org.eclipse.gemoc.addon.metaprogramming/src/org/eclipse/gemoc/addon/metaprogramming/MOCCMLRuleProvider.java
+++ b/concurrent_addons/plugins/org.eclipse.gemoc.addon.metaprogramming/src/org/eclipse/gemoc/addon/metaprogramming/MOCCMLRuleProvider.java
@@ -6,14 +6,21 @@ import java.util.Collection;
 import org.eclipse.gemoc.xdsmlframework.api.extensions.metaprog.IRule;
 import org.eclipse.gemoc.xdsmlframework.api.extensions.metaprog.IRuleProvider;
 import org.eclipse.gemoc.xdsmlframework.api.extensions.metaprog.EcoreRule;
+import org.eclipse.gemoc.xdsmlframework.extensions.kermeta3.Kermeta3Rule;
 
 public class MOCCMLRuleProvider implements IRuleProvider {
+	
+	private ArrayList<IRule> ruleSet;
 
+	public MOCCMLRuleProvider() {
+		ruleSet = new ArrayList<IRule>();
+	}
+	
 	@Override
 	public Collection<IRule> getValidationRules() {
-		ArrayList<IRule> ruleSet = new ArrayList<IRule>();
 		ruleSet.add(new EcoreRule());
 		ruleSet.add(new MOCCMLRule());
+		ruleSet.add(new Kermeta3Rule(false));
 		return ruleSet;
 	}
 


### PR DESCRIPTION
K3 validation rule moved to reduce code duplication between K3 validation plug-in and MOCCML validation plug-in.

Signed-off-by: Ronan Guéguen <gueguen.ronan1@gmail.com>