### PR TITLE
Metaprogramming approach name changed to FullyQualifiedName

### DIFF
--- a/concurrent_addons/plugins/org.eclipse.gemoc.addon.metaprogramming/plugin.xml
+++ b/concurrent_addons/plugins/org.eclipse.gemoc.addon.metaprogramming/plugin.xml
@@ -4,7 +4,7 @@
    <extension
          point="org.eclipse.gemoc.gemoc_language_workbench.metaprog">
       <approach
-            name="org.eclipse.gemoc.moccml"
+            name="org.eclipse.gemoc.metaprog.moccml"
             validator="org.eclipse.gemoc.addon.metaprogramming.MOCCMLRuleProvider">
       </approach>
    </extension>

--- a/concurrent_addons/plugins/org.eclipse.gemoc.addon.metaprogramming/plugin.xml
+++ b/concurrent_addons/plugins/org.eclipse.gemoc.addon.metaprogramming/plugin.xml
@@ -4,7 +4,7 @@
    <extension
          point="org.eclipse.gemoc.gemoc_language_workbench.metaprog">
       <approach
-            name="moccml"
+            name="org.eclipse.gemoc.moccml"
             validator="org.eclipse.gemoc.addon.metaprogramming.MOCCMLRuleProvider">
       </approach>
    </extension>


### PR DESCRIPTION
Name changed from "moccml" to "org.eclipse.gemoc.metaprog.moccml".

Signed-off-by: Ronan Guéguen <gueguen.ronan1@gmail.com>