### PR TITLE
Bump eclipse 2020-12

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
   <extension>
     <groupId>org.eclipse.tycho.extras</groupId>
     <artifactId>tycho-pomless</artifactId>
-    <version>1.7.0</version>
+    <version>2.2.0</version>
   </extension>
 </extensions>

--- a/examples/moccmlSigPML/modeling_workbench/org.eclipse.gemoc.example.moccmlsigpml.simple_example/Simple.aird
+++ b/examples/moccmlSigPML/modeling_workbench/org.eclipse.gemoc.example.moccmlsigpml.simple_example/Simple.aird
@@ -1,39 +1,45 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:description="http://www.eclipse.org/sirius/description/1.1.0" xmlns:description_1="http://www.eclipse.org/sirius/diagram/description/1.1.0" xmlns:diagram="http://www.eclipse.org/sirius/diagram/1.1.0" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:sigpml="http://org.eclipse.gemoc.example.moccmlsigpml.model/1.0" xmlns:style="http://www.eclipse.org/sirius/diagram/description/style/1.1.0" xmlns:viewpoint="http://www.eclipse.org/sirius/1.1.0" xsi:schemaLocation="http://www.eclipse.org/sirius/description/1.1.0 http://www.eclipse.org/sirius/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/style/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description/style">
-  <viewpoint:DAnalysis xmi:id="_npaSEGAyEemFMZX_sTS_2A" selectedViews="_oHlb0GAyEemFMZX_sTS_2A" version="13.0.0.201804031646">
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:description="http://www.eclipse.org/sirius/description/1.1.0" xmlns:description_1="http://www.eclipse.org/sirius/diagram/description/1.1.0" xmlns:diagram="http://www.eclipse.org/sirius/diagram/1.1.0" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.3/notation" xmlns:sigpml="http://org.eclipse.gemoc.example.moccmlsigpml.model/1.0" xmlns:style="http://www.eclipse.org/sirius/diagram/description/style/1.1.0" xmlns:viewpoint="http://www.eclipse.org/sirius/1.1.0" xsi:schemaLocation="http://www.eclipse.org/sirius/description/1.1.0 http://www.eclipse.org/sirius/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/style/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description/style">
+  <viewpoint:DAnalysis uid="_npaSEGAyEemFMZX_sTS_2A" selectedViews="_oHlb0GAyEemFMZX_sTS_2A" version="14.3.1.202003261200">
     <semanticResources>Simple.sigpml</semanticResources>
-    <ownedViews xmi:type="viewpoint:DView" xmi:id="_oHlb0GAyEemFMZX_sTS_2A">
+    <ownedViews xmi:type="viewpoint:DView" uid="_oHlb0GAyEemFMZX_sTS_2A">
       <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']"/>
-      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" xmi:id="_oOWLIGAyEemFMZX_sTS_2A" name="simpleSystem" repPath="#_oKhbEGAyEemFMZX_sTS_2A">
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_oOWLIGAyEemFMZX_sTS_2A" name="simpleSystem" repPath="#_oOR5sGAyEemFMZX_sTS_2A" changeId="9d7ab8eb-5fed-4857-9166-4df74e2ae64c">
         <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']"/>
         <target xmi:type="sigpml:System" href="Simple.sigpml#/"/>
       </ownedRepresentationDescriptors>
     </ownedViews>
   </viewpoint:DAnalysis>
-  <diagram:DSemanticDiagram xmi:id="_oOR5sGAyEemFMZX_sTS_2A" name="simpleSystem" uid="_oKhbEGAyEemFMZX_sTS_2A">
-    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" xmi:id="_oOSgwGAyEemFMZX_sTS_2A" source="DANNOTATION_CUSTOMIZATION_KEY">
-      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" xmi:id="_oOSgwWAyEemFMZX_sTS_2A">
-        <computedStyleDescriptions xmi:type="style:EllipseNodeDescription" xmi:id="_nVOsoGBEEemmktx-QOZ7oA" borderSizeComputationExpression="1" showIcon="false" labelExpression="[self.name + '\n execTime:' + (self.cycles-1)/]" sizeComputationExpression="[self.name.size()+6/]" labelPosition="node" resizeKind="NSEW">
+  <diagram:DSemanticDiagram uid="_oOR5sGAyEemFMZX_sTS_2A">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_oOSgwGAyEemFMZX_sTS_2A" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_oOSgwWAyEemFMZX_sTS_2A">
+        <computedStyleDescriptions xmi:type="style:EllipseNodeDescription" xmi:id="_dpKVMFs-EeuVkrz0RM5Fbg" borderSizeComputationExpression="1" showIcon="false" labelExpression="A1&#xA;invalid on 2" sizeComputationExpression="[self.name.size()+6/]" labelPosition="node" resizeKind="NSEW">
           <borderColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='dark_blue']"/>
           <labelFormat>bold</labelFormat>
           <labelColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='dark_blue']"/>
           <color xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='white']"/>
         </computedStyleDescriptions>
-        <computedStyleDescriptions xmi:type="style:EdgeStyleDescription" xmi:id="_nenSIGBEEemmktx-QOZ7oA" sizeComputationExpression="2" routingStyle="manhattan">
+        <computedStyleDescriptions xmi:type="style:EllipseNodeDescription" xmi:id="_dpaM0Fs-EeuVkrz0RM5Fbg" borderSizeComputationExpression="1" showIcon="false" labelExpression="A2&#xA;invalid on 4" sizeComputationExpression="[self.name.size()+6/]" labelPosition="node" resizeKind="NSEW">
+          <borderColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='dark_blue']"/>
+          <labelFormat>bold</labelFormat>
+          <labelColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='dark_blue']"/>
+          <color xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='white']"/>
+        </computedStyleDescriptions>
+        <computedStyleDescriptions xmi:type="style:EdgeStyleDescription" xmi:id="_dqACsFs-EeuVkrz0RM5Fbg" sizeComputationExpression="2" routingStyle="manhattan">
           <strokeColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='green']"/>
-          <centerLabelStyleDescription xmi:type="style:CenterLabelStyleDescription" xmi:id="_nenSIWBEEemmktx-QOZ7oA" labelSize="9" showIcon="false" labelExpression="0 / 6">
+          <centerLabelStyleDescription xmi:type="style:CenterLabelStyleDescription" xmi:id="_dqACsVs-EeuVkrz0RM5Fbg" labelSize="9" showIcon="false" labelExpression="invalid / 6">
             <labelColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
           </centerLabelStyleDescription>
         </computedStyleDescriptions>
-        <computedStyleDescriptions xmi:type="style:EdgeStyleDescription" xmi:id="_neq8gGBEEemmktx-QOZ7oA" sizeComputationExpression="2" routingStyle="manhattan">
+        <computedStyleDescriptions xmi:type="style:EdgeStyleDescription" xmi:id="_dqEUIFs-EeuVkrz0RM5Fbg" sizeComputationExpression="2" routingStyle="manhattan">
           <strokeColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='green']"/>
-          <centerLabelStyleDescription xmi:type="style:CenterLabelStyleDescription" xmi:id="_neq8gWBEEemmktx-QOZ7oA" labelSize="9" showIcon="false" labelExpression="0 / 1">
+          <centerLabelStyleDescription xmi:type="style:CenterLabelStyleDescription" xmi:id="_dqEUIVs-EeuVkrz0RM5Fbg" labelSize="9" showIcon="false" labelExpression="invalid / 1">
             <labelColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
           </centerLabelStyleDescription>
         </computedStyleDescriptions>
       </data>
     </ownedAnnotationEntries>
-    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" xmi:id="_oOptIGAyEemFMZX_sTS_2A" source="GMF_DIAGRAMS">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_oOptIGAyEemFMZX_sTS_2A" source="GMF_DIAGRAMS">
       <data xmi:type="notation:Diagram" xmi:id="_oOptIWAyEemFMZX_sTS_2A" type="Sirius" element="_oOR5sGAyEemFMZX_sTS_2A" measurementUnit="Pixel">
         <children xmi:type="notation:Node" xmi:id="_oO1TUGAyEemFMZX_sTS_2A" type="2002" element="_oOSgw2AyEemFMZX_sTS_2A">
           <children xmi:type="notation:Node" xmi:id="_oO7Z8GAyEemFMZX_sTS_2A" type="5006"/>
@@ -117,9 +123,9 @@
                 <styles xmi:type="notation:ShapeStyle" xmi:id="_oPW3wmAyEemFMZX_sTS_2A" fontName="Noto Sans" fontHeight="5"/>
                 <layoutConstraint xmi:type="notation:Bounds" xmi:id="_oPW3w2AyEemFMZX_sTS_2A" y="-12" width="48" height="20"/>
               </children>
-              <children xmi:type="notation:Node" xmi:id="_ne5mAGBEEemmktx-QOZ7oA" type="3016" element="_nVPTsGBEEemmktx-QOZ7oA">
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_ne5mAWBEEemmktx-QOZ7oA" fontName="Noto Sans"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ne5mAmBEEemmktx-QOZ7oA"/>
+              <children xmi:type="notation:Node" xmi:id="_dqjcUFs-EeuVkrz0RM5Fbg" type="3016" element="_dpK8QVs-EeuVkrz0RM5Fbg">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_dqjcUVs-EeuVkrz0RM5Fbg" fontName="Noto Sans"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dqjcUls-EeuVkrz0RM5Fbg"/>
               </children>
               <styles xmi:type="notation:ShapeStyle" xmi:id="_oPT0cWAyEemFMZX_sTS_2A" fontColor="7490599" fontName="Noto Sans" fontHeight="8" bold="true"/>
               <layoutConstraint xmi:type="notation:Bounds" xmi:id="_oPT0cmAyEemFMZX_sTS_2A" x="91" y="42" width="80" height="80"/>
@@ -139,9 +145,9 @@
                 <styles xmi:type="notation:ShapeStyle" xmi:id="_oPaiIWAyEemFMZX_sTS_2A" fontName="Noto Sans" fontHeight="5"/>
                 <layoutConstraint xmi:type="notation:Bounds" xmi:id="_oPaiImAyEemFMZX_sTS_2A" x="-24" y="24" width="32" height="20"/>
               </children>
-              <children xmi:type="notation:Node" xmi:id="_ne60IGBEEemmktx-QOZ7oA" type="3016" element="_nd5gcGBEEemmktx-QOZ7oA">
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_ne60IWBEEemmktx-QOZ7oA" fontName="Noto Sans"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ne60ImBEEemmktx-QOZ7oA"/>
+              <children xmi:type="notation:Node" xmi:id="_dqkqcFs-EeuVkrz0RM5Fbg" type="3016" element="_dpaz4Vs-EeuVkrz0RM5Fbg">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_dqkqcVs-EeuVkrz0RM5Fbg" fontName="Noto Sans"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dqkqcls-EeuVkrz0RM5Fbg"/>
               </children>
               <styles xmi:type="notation:ShapeStyle" xmi:id="_oPUbgWAyEemFMZX_sTS_2A" fontColor="7490599" fontName="Noto Sans" fontHeight="8" bold="true"/>
               <layoutConstraint xmi:type="notation:Bounds" xmi:id="_oPUbgmAyEemFMZX_sTS_2A" x="343" y="42" width="80" height="80"/>
@@ -267,94 +273,94 @@
         </edges>
       </data>
     </ownedAnnotationEntries>
-    <ownedDiagramElements xmi:type="diagram:DNodeContainer" xmi:id="_oOSgw2AyEemFMZX_sTS_2A" name="platform1">
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_oOSgw2AyEemFMZX_sTS_2A" name="platform1">
       <target xmi:type="sigpml:HWPlatform" href="Simple.sigpml#//@ownedHWPlatform"/>
       <semanticElements xmi:type="sigpml:HWPlatform" href="Simple.sigpml#//@ownedHWPlatform"/>
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
       <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
       <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-      <ownedStyle xmi:type="diagram:ShapeContainerStyle" xmi:id="_oOSgxGAyEemFMZX_sTS_2A" showIcon="false" borderSize="2" borderSizeComputationExpression="2" borderColor="39,76,114" backgroundColor="255,255,255">
+      <ownedStyle xmi:type="diagram:ShapeContainerStyle" uid="_oOSgxGAyEemFMZX_sTS_2A" showIcon="false" borderSize="2" borderSizeComputationExpression="2" borderColor="39,76,114" backgroundColor="255,255,255">
         <description xmi:type="style:ShapeContainerStyleDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']/@defaultLayer/@containerMappings[name='HWPlatform']/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']/@defaultLayer/@containerMappings[name='HWPlatform']"/>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_oOSgxWAyEemFMZX_sTS_2A" name="CPU1&#xA;(is preemptive=true) " outgoingEdges="_oOSg32AyEemFMZX_sTS_2A _oOSg4mAyEemFMZX_sTS_2A _oOSg5WAyEemFMZX_sTS_2A" width="-1" height="-1" resizeKind="NSEW">
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_oOSgxWAyEemFMZX_sTS_2A" name="CPU1&#xA;(is preemptive=true) " outgoingEdges="_oOSg32AyEemFMZX_sTS_2A _oOSg4mAyEemFMZX_sTS_2A _oOSg5WAyEemFMZX_sTS_2A" width="-1" height="-1" resizeKind="NSEW">
         <target xmi:type="sigpml:HWComputationalResource" href="Simple.sigpml#//@ownedHWPlatform/@ownedHWResources.0"/>
         <semanticElements xmi:type="sigpml:HWComputationalResource" href="Simple.sigpml#//@ownedHWPlatform/@ownedHWResources.0"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:WorkspaceImage" xmi:id="_oOSgxmAyEemFMZX_sTS_2A" showIcon="false" labelAlignment="LEFT" workspacePath="/org.eclipse.gemoc.example.moccmlsigpml.design/picts/ksim_cpu.png">
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_oOSgxmAyEemFMZX_sTS_2A" showIcon="false" labelAlignment="LEFT" workspacePath="/org.eclipse.gemoc.example.moccmlsigpml.design/picts/ksim_cpu.png">
           <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']/@defaultLayer/@containerMappings[name='HWPlatform']/@subNodeMappings[name='HWComputationalResource']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']/@defaultLayer/@containerMappings[name='HWPlatform']/@subNodeMappings[name='HWComputationalResource']"/>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_oOSgx2AyEemFMZX_sTS_2A" name="mem1" outgoingEdges="_oOSg6GAyEemFMZX_sTS_2A _oOSg62AyEemFMZX_sTS_2A" width="-1" height="-1" resizeKind="NSEW">
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_oOSgx2AyEemFMZX_sTS_2A" name="mem1" outgoingEdges="_oOSg6GAyEemFMZX_sTS_2A _oOSg62AyEemFMZX_sTS_2A" width="-1" height="-1" resizeKind="NSEW">
         <target xmi:type="sigpml:HWStorageResource" href="Simple.sigpml#//@ownedHWPlatform/@ownedHWResources.2"/>
         <semanticElements xmi:type="sigpml:HWStorageResource" href="Simple.sigpml#//@ownedHWPlatform/@ownedHWResources.2"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:WorkspaceImage" xmi:id="_oOSgyGAyEemFMZX_sTS_2A" showIcon="false" labelAlignment="RIGHT" workspacePath="/org.eclipse.gemoc.example.moccmlsigpml.design/picts/ram_small.png">
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_oOSgyGAyEemFMZX_sTS_2A" showIcon="false" labelAlignment="RIGHT" workspacePath="/org.eclipse.gemoc.example.moccmlsigpml.design/picts/ram_small.png">
           <labelFormat>bold</labelFormat>
           <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']/@defaultLayer/@containerMappings[name='HWPlatform']/@subNodeMappings[name='HWStorageResources']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']/@defaultLayer/@containerMappings[name='HWPlatform']/@subNodeMappings[name='HWStorageResources']"/>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_oOSgyWAyEemFMZX_sTS_2A" name="bus1" incomingEdges="_oOSg5WAyEemFMZX_sTS_2A _oOSg6GAyEemFMZX_sTS_2A" width="-1" height="-1" resizeKind="NSEW">
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_oOSgyWAyEemFMZX_sTS_2A" name="bus1" incomingEdges="_oOSg5WAyEemFMZX_sTS_2A _oOSg6GAyEemFMZX_sTS_2A" width="-1" height="-1" resizeKind="NSEW">
         <target xmi:type="sigpml:HWCommunicationResource" href="Simple.sigpml#//@ownedHWPlatform/@ownedHWResources.1"/>
         <semanticElements xmi:type="sigpml:HWCommunicationResource" href="Simple.sigpml#//@ownedHWPlatform/@ownedHWResources.1"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:WorkspaceImage" xmi:id="_oOSgymAyEemFMZX_sTS_2A" showIcon="false" labelPosition="node" workspacePath="/org.eclipse.gemoc.example.moccmlsigpml.design/picts/Bus_small.png">
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_oOSgymAyEemFMZX_sTS_2A" showIcon="false" labelPosition="node" workspacePath="/org.eclipse.gemoc.example.moccmlsigpml.design/picts/Bus_small.png">
           <labelFormat>bold</labelFormat>
           <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']/@defaultLayer/@containerMappings[name='HWPlatform']/@subNodeMappings[name='HWCommunicationResource']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']/@defaultLayer/@containerMappings[name='HWPlatform']/@subNodeMappings[name='HWCommunicationResource']"/>
       </ownedDiagramElements>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNodeContainer" xmi:id="_oOSgy2AyEemFMZX_sTS_2A" name="appli1">
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_oOSgy2AyEemFMZX_sTS_2A" name="appli1">
       <target xmi:type="sigpml:Application" href="Simple.sigpml#//@ownedApplication"/>
       <semanticElements xmi:type="sigpml:Application" href="Simple.sigpml#//@ownedApplication"/>
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
       <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
       <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-      <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_oOSgzGAyEemFMZX_sTS_2A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" backgroundColor="255,255,230" foregroundColor="255,255,255">
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_oOSgzGAyEemFMZX_sTS_2A" showIcon="false" borderSize="1" borderSizeComputationExpression="1" backgroundColor="255,255,230" foregroundColor="255,255,255">
         <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']/@defaultLayer/@containerMappings[name='Application']/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']/@defaultLayer/@containerMappings[name='Application']"/>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_oOSgzWAyEemFMZX_sTS_2A" name="A1&#xA; execTime:1" incomingEdges="_oOSg32AyEemFMZX_sTS_2A" width="8" height="8" resizeKind="NSEW">
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_oOSgzWAyEemFMZX_sTS_2A" name="A1&#xA;invalid on 2" incomingEdges="_oOSg32AyEemFMZX_sTS_2A" width="8" height="8" resizeKind="NSEW">
         <target xmi:type="sigpml:Agent" href="Simple.sigpml#//@ownedApplication/@ownedAgents.0"/>
         <semanticElements xmi:type="sigpml:Agent" href="Simple.sigpml#//@ownedApplication/@ownedAgents.0"/>
-        <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_oOSgzmAyEemFMZX_sTS_2A" name="pA1inState" incomingEdges="_oOSg3GAyEemFMZX_sTS_2A" width="2" height="2" resizeKind="NSEW">
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_oOSgzmAyEemFMZX_sTS_2A" name="pA1inState" incomingEdges="_oOSg3GAyEemFMZX_sTS_2A" width="2" height="2" resizeKind="NSEW">
           <target xmi:type="sigpml:InputPort" href="Simple.sigpml#//@ownedApplication/@ownedAgents.0/@ownedPorts.1"/>
           <semanticElements xmi:type="sigpml:InputPort" href="Simple.sigpml#//@ownedApplication/@ownedAgents.0/@ownedPorts.1"/>
           <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
           <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
           <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_oOSgz2AyEemFMZX_sTS_2A" labelSize="5" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="77,137,20" labelPosition="node" color="255,255,230">
+          <ownedStyle xmi:type="diagram:Square" uid="_oOSgz2AyEemFMZX_sTS_2A" labelSize="5" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="77,137,20" labelPosition="node" color="255,255,230">
             <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']/@defaultLayer/@containerMappings[name='Application']/@subNodeMappings[name='Agent']/@borderedNodeMappings[name='InputPort']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']/@defaultLayer/@containerMappings[name='Application']/@subNodeMappings[name='Agent']/@borderedNodeMappings[name='InputPort']"/>
         </ownedBorderedNodes>
-        <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_oOSg0GAyEemFMZX_sTS_2A" name="pA1out" outgoingEdges="_oOSg2WAyEemFMZX_sTS_2A" width="2" height="2" resizeKind="NSEW">
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_oOSg0GAyEemFMZX_sTS_2A" name="pA1out" outgoingEdges="_oOSg2WAyEemFMZX_sTS_2A" width="2" height="2" resizeKind="NSEW">
           <target xmi:type="sigpml:OutputPort" href="Simple.sigpml#//@ownedApplication/@ownedAgents.0/@ownedPorts.0"/>
           <semanticElements xmi:type="sigpml:OutputPort" href="Simple.sigpml#//@ownedApplication/@ownedAgents.0/@ownedPorts.0"/>
           <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
           <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
           <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_oOSg0WAyEemFMZX_sTS_2A" labelSize="5" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="156,12,12" labelPosition="node" color="255,255,230">
+          <ownedStyle xmi:type="diagram:Square" uid="_oOSg0WAyEemFMZX_sTS_2A" labelSize="5" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="156,12,12" labelPosition="node" color="255,255,230">
             <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']/@defaultLayer/@containerMappings[name='Application']/@subNodeMappings[name='Agent']/@borderedNodeMappings[name='OutputPort']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']/@defaultLayer/@containerMappings[name='Application']/@subNodeMappings[name='Agent']/@borderedNodeMappings[name='OutputPort']"/>
         </ownedBorderedNodes>
-        <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_oOSg0mAyEemFMZX_sTS_2A" name="pA1outState" outgoingEdges="_oOSg3GAyEemFMZX_sTS_2A" width="2" height="2" resizeKind="NSEW">
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_oOSg0mAyEemFMZX_sTS_2A" name="pA1outState" outgoingEdges="_oOSg3GAyEemFMZX_sTS_2A" width="2" height="2" resizeKind="NSEW">
           <target xmi:type="sigpml:OutputPort" href="Simple.sigpml#//@ownedApplication/@ownedAgents.0/@ownedPorts.2"/>
           <semanticElements xmi:type="sigpml:OutputPort" href="Simple.sigpml#//@ownedApplication/@ownedAgents.0/@ownedPorts.2"/>
           <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
           <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
           <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_oOSg02AyEemFMZX_sTS_2A" labelSize="5" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="156,12,12" labelPosition="node" color="255,255,230">
+          <ownedStyle xmi:type="diagram:Square" uid="_oOSg02AyEemFMZX_sTS_2A" labelSize="5" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="156,12,12" labelPosition="node" color="255,255,230">
             <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']/@defaultLayer/@containerMappings[name='Application']/@subNodeMappings[name='Agent']/@borderedNodeMappings[name='OutputPort']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']/@defaultLayer/@containerMappings[name='Application']/@subNodeMappings[name='Agent']/@borderedNodeMappings[name='OutputPort']"/>
@@ -362,21 +368,21 @@
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:Ellipse" xmi:id="_nVPTsGBEEemmktx-QOZ7oA" showIcon="false" labelColor="39,76,114" description="_nVOsoGBEEemmktx-QOZ7oA" borderSize="1" borderSizeComputationExpression="1" borderColor="39,76,114" labelPosition="node" color="255,255,255">
+        <ownedStyle xmi:type="diagram:Ellipse" uid="_dpK8QVs-EeuVkrz0RM5Fbg" showIcon="false" labelColor="39,76,114" description="_dpKVMFs-EeuVkrz0RM5Fbg" borderSize="1" borderSizeComputationExpression="1" borderColor="39,76,114" labelPosition="node" color="255,255,255">
           <labelFormat>bold</labelFormat>
         </ownedStyle>
         <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']/@defaultLayer/@containerMappings[name='Application']/@subNodeMappings[name='Agent']"/>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_oOSg1WAyEemFMZX_sTS_2A" name="A2&#xA; execTime:3" incomingEdges="_oOSg4mAyEemFMZX_sTS_2A" width="8" height="8" resizeKind="NSEW">
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_oOSg1WAyEemFMZX_sTS_2A" name="A2&#xA;invalid on 4" incomingEdges="_oOSg4mAyEemFMZX_sTS_2A" width="8" height="8" resizeKind="NSEW">
         <target xmi:type="sigpml:Agent" href="Simple.sigpml#//@ownedApplication/@ownedAgents.1"/>
         <semanticElements xmi:type="sigpml:Agent" href="Simple.sigpml#//@ownedApplication/@ownedAgents.1"/>
-        <ownedBorderedNodes xmi:type="diagram:DNode" xmi:id="_oOSg1mAyEemFMZX_sTS_2A" name="pA2in" incomingEdges="_oOSg2WAyEemFMZX_sTS_2A" width="2" height="2" resizeKind="NSEW">
+        <ownedBorderedNodes xmi:type="diagram:DNode" uid="_oOSg1mAyEemFMZX_sTS_2A" name="pA2in" incomingEdges="_oOSg2WAyEemFMZX_sTS_2A" width="2" height="2" resizeKind="NSEW">
           <target xmi:type="sigpml:InputPort" href="Simple.sigpml#//@ownedApplication/@ownedAgents.1/@ownedPorts.0"/>
           <semanticElements xmi:type="sigpml:InputPort" href="Simple.sigpml#//@ownedApplication/@ownedAgents.1/@ownedPorts.0"/>
           <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
           <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
           <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-          <ownedStyle xmi:type="diagram:Square" xmi:id="_oOSg12AyEemFMZX_sTS_2A" labelSize="5" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="77,137,20" labelPosition="node" color="255,255,230">
+          <ownedStyle xmi:type="diagram:Square" uid="_oOSg12AyEemFMZX_sTS_2A" labelSize="5" showIcon="false" borderSize="1" borderSizeComputationExpression="1" borderColor="77,137,20" labelPosition="node" color="255,255,230">
             <description xmi:type="style:SquareDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']/@defaultLayer/@containerMappings[name='Application']/@subNodeMappings[name='Agent']/@borderedNodeMappings[name='InputPort']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']/@defaultLayer/@containerMappings[name='Application']/@subNodeMappings[name='Agent']/@borderedNodeMappings[name='InputPort']"/>
@@ -384,70 +390,70 @@
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:Ellipse" xmi:id="_nd5gcGBEEemmktx-QOZ7oA" showIcon="false" labelColor="39,76,114" description="_nVOsoGBEEemmktx-QOZ7oA" borderSize="1" borderSizeComputationExpression="1" borderColor="39,76,114" labelPosition="node" color="255,255,255">
+        <ownedStyle xmi:type="diagram:Ellipse" uid="_dpaz4Vs-EeuVkrz0RM5Fbg" showIcon="false" labelColor="39,76,114" description="_dpaM0Fs-EeuVkrz0RM5Fbg" borderSize="1" borderSizeComputationExpression="1" borderColor="39,76,114" labelPosition="node" color="255,255,255">
           <labelFormat>bold</labelFormat>
         </ownedStyle>
         <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']/@defaultLayer/@containerMappings[name='Application']/@subNodeMappings[name='Agent']"/>
       </ownedDiagramElements>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_oOSg2WAyEemFMZX_sTS_2A" name="0 / 6" incomingEdges="_oOSg62AyEemFMZX_sTS_2A" sourceNode="_oOSg0GAyEemFMZX_sTS_2A" targetNode="_oOSg1mAyEemFMZX_sTS_2A">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_oOSg2WAyEemFMZX_sTS_2A" name="invalid / 6" incomingEdges="_oOSg62AyEemFMZX_sTS_2A" sourceNode="_oOSg0GAyEemFMZX_sTS_2A" targetNode="_oOSg1mAyEemFMZX_sTS_2A">
       <target xmi:type="sigpml:Place" href="Simple.sigpml#//@ownedApplication/@ownedPlaces.0"/>
       <semanticElements xmi:type="sigpml:Place" href="Simple.sigpml#//@ownedApplication/@ownedPlaces.0"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_nen5MGBEEemmktx-QOZ7oA" description="_nenSIGBEEemmktx-QOZ7oA" size="2" routingStyle="manhattan" strokeColor="138,226,52">
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_nen5MWBEEemmktx-QOZ7oA" labelSize="9" showIcon="false"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_dqACsls-EeuVkrz0RM5Fbg" description="_dqACsFs-EeuVkrz0RM5Fbg" size="2" routingStyle="manhattan" strokeColor="138,226,52">
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_dqACs1s-EeuVkrz0RM5Fbg" labelSize="9" showIcon="false"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']/@defaultLayer/@edgeMappings[name='Place']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_oOSg3GAyEemFMZX_sTS_2A" name="0 / 1" sourceNode="_oOSg0mAyEemFMZX_sTS_2A" targetNode="_oOSgzmAyEemFMZX_sTS_2A">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_oOSg3GAyEemFMZX_sTS_2A" name="invalid / 1" sourceNode="_oOSg0mAyEemFMZX_sTS_2A" targetNode="_oOSgzmAyEemFMZX_sTS_2A">
       <target xmi:type="sigpml:Place" href="Simple.sigpml#//@ownedApplication/@ownedPlaces.1"/>
       <semanticElements xmi:type="sigpml:Place" href="Simple.sigpml#//@ownedApplication/@ownedPlaces.1"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_nerjkGBEEemmktx-QOZ7oA" description="_neq8gGBEEemmktx-QOZ7oA" size="2" routingStyle="manhattan" strokeColor="138,226,52">
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_nerjkWBEEemmktx-QOZ7oA" labelSize="9" showIcon="false"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_dqEUIls-EeuVkrz0RM5Fbg" description="_dqEUIFs-EeuVkrz0RM5Fbg" size="2" routingStyle="manhattan" strokeColor="138,226,52">
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_dqEUI1s-EeuVkrz0RM5Fbg" labelSize="9" showIcon="false"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']/@defaultLayer/@edgeMappings[name='Place']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_oOSg32AyEemFMZX_sTS_2A" sourceNode="_oOSgxWAyEemFMZX_sTS_2A" targetNode="_oOSgzWAyEemFMZX_sTS_2A">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_oOSg32AyEemFMZX_sTS_2A" sourceNode="_oOSgxWAyEemFMZX_sTS_2A" targetNode="_oOSgzWAyEemFMZX_sTS_2A">
       <target xmi:type="sigpml:HWComputationalResource" href="Simple.sigpml#//@ownedHWPlatform/@ownedHWResources.0"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_oOSg4GAyEemFMZX_sTS_2A" lineStyle="dash" sourceArrow="InputArrow" targetArrow="NoDecoration" size="2">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_oOSg4GAyEemFMZX_sTS_2A" lineStyle="dash" sourceArrow="InputArrow" targetArrow="NoDecoration" size="2">
         <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']/@defaultLayer/@edgeMappings[name='AgentAllocation']/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_oOSg4WAyEemFMZX_sTS_2A"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_oOSg4WAyEemFMZX_sTS_2A"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']/@defaultLayer/@edgeMappings[name='AgentAllocation']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_oOSg4mAyEemFMZX_sTS_2A" sourceNode="_oOSgxWAyEemFMZX_sTS_2A" targetNode="_oOSg1WAyEemFMZX_sTS_2A">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_oOSg4mAyEemFMZX_sTS_2A" sourceNode="_oOSgxWAyEemFMZX_sTS_2A" targetNode="_oOSg1WAyEemFMZX_sTS_2A">
       <target xmi:type="sigpml:HWComputationalResource" href="Simple.sigpml#//@ownedHWPlatform/@ownedHWResources.0"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_oOSg42AyEemFMZX_sTS_2A" lineStyle="dash" sourceArrow="InputArrow" targetArrow="NoDecoration" size="2">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_oOSg42AyEemFMZX_sTS_2A" lineStyle="dash" sourceArrow="InputArrow" targetArrow="NoDecoration" size="2">
         <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']/@defaultLayer/@edgeMappings[name='AgentAllocation']/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_oOSg5GAyEemFMZX_sTS_2A"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_oOSg5GAyEemFMZX_sTS_2A"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']/@defaultLayer/@edgeMappings[name='AgentAllocation']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_oOSg5WAyEemFMZX_sTS_2A" sourceNode="_oOSgxWAyEemFMZX_sTS_2A" targetNode="_oOSgyWAyEemFMZX_sTS_2A">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_oOSg5WAyEemFMZX_sTS_2A" sourceNode="_oOSgxWAyEemFMZX_sTS_2A" targetNode="_oOSgyWAyEemFMZX_sTS_2A">
       <target xmi:type="sigpml:HWComputationalResource" href="Simple.sigpml#//@ownedHWPlatform/@ownedHWResources.0"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_oOSg5mAyEemFMZX_sTS_2A" size="2" strokeColor="0,0,0">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_oOSg5mAyEemFMZX_sTS_2A" size="2" strokeColor="0,0,0">
         <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']/@defaultLayer/@edgeMappings[name='']/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_oOSg52AyEemFMZX_sTS_2A"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_oOSg52AyEemFMZX_sTS_2A"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']/@defaultLayer/@edgeMappings[name='']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_oOSg6GAyEemFMZX_sTS_2A" sourceNode="_oOSgx2AyEemFMZX_sTS_2A" targetNode="_oOSgyWAyEemFMZX_sTS_2A">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_oOSg6GAyEemFMZX_sTS_2A" sourceNode="_oOSgx2AyEemFMZX_sTS_2A" targetNode="_oOSgyWAyEemFMZX_sTS_2A">
       <target xmi:type="sigpml:HWStorageResource" href="Simple.sigpml#//@ownedHWPlatform/@ownedHWResources.2"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_oOSg6WAyEemFMZX_sTS_2A" size="2" strokeColor="0,0,0">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_oOSg6WAyEemFMZX_sTS_2A" size="2" strokeColor="0,0,0">
         <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']/@defaultLayer/@edgeMappings[name='']/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_oOSg6mAyEemFMZX_sTS_2A"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_oOSg6mAyEemFMZX_sTS_2A"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']/@defaultLayer/@edgeMappings[name='']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_oOSg62AyEemFMZX_sTS_2A" sourceNode="_oOSgx2AyEemFMZX_sTS_2A" targetNode="_oOSg2WAyEemFMZX_sTS_2A">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_oOSg62AyEemFMZX_sTS_2A" sourceNode="_oOSgx2AyEemFMZX_sTS_2A" targetNode="_oOSg2WAyEemFMZX_sTS_2A">
       <target xmi:type="sigpml:HWStorageResource" href="Simple.sigpml#//@ownedHWPlatform/@ownedHWResources.2"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_oOSg7GAyEemFMZX_sTS_2A" lineStyle="dash" sourceArrow="InputArrow" targetArrow="NoDecoration" size="2">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_oOSg7GAyEemFMZX_sTS_2A" lineStyle="dash" sourceArrow="InputArrow" targetArrow="NoDecoration" size="2">
         <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']/@defaultLayer/@edgeMappings[name='PlaceAllocation']/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_oOSg7WAyEemFMZX_sTS_2A"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_oOSg7WAyEemFMZX_sTS_2A"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']/@defaultLayer/@edgeMappings[name='PlaceAllocation']"/>
     </ownedDiagramElements>
     <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']"/>
-    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" xmi:id="_oOSg7mAyEemFMZX_sTS_2A"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_oOSg7mAyEemFMZX_sTS_2A"/>
     <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']/@defaultLayer"/>
     <activatedLayers xmi:type="description_1:AdditionalLayer" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']/@additionalLayers[name='SigPMLAnimation']"/>
     <target xmi:type="sigpml:System" href="Simple.sigpml#/"/>

--- a/examples/moccmlSigPML/modeling_workbench/org.eclipse.gemoc.example.moccmlsigpml.simple_example/Simple.aird
+++ b/examples/moccmlSigPML/modeling_workbench/org.eclipse.gemoc.example.moccmlsigpml.simple_example/Simple.aird
@@ -4,7 +4,7 @@
     <semanticResources>Simple.sigpml</semanticResources>
     <ownedViews xmi:type="viewpoint:DView" uid="_oHlb0GAyEemFMZX_sTS_2A">
       <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']"/>
-      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_oOWLIGAyEemFMZX_sTS_2A" name="simpleSystem" repPath="#_oOR5sGAyEemFMZX_sTS_2A" changeId="9d7ab8eb-5fed-4857-9166-4df74e2ae64c">
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_oOWLIGAyEemFMZX_sTS_2A" name="simpleSystem" repPath="#_oOR5sGAyEemFMZX_sTS_2A" changeId="2b765a83-fb48-477c-9024-d311c2c1545c">
         <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']"/>
         <target xmi:type="sigpml:System" href="Simple.sigpml#/"/>
       </ownedRepresentationDescriptors>
@@ -13,27 +13,27 @@
   <diagram:DSemanticDiagram uid="_oOR5sGAyEemFMZX_sTS_2A">
     <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_oOSgwGAyEemFMZX_sTS_2A" source="DANNOTATION_CUSTOMIZATION_KEY">
       <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_oOSgwWAyEemFMZX_sTS_2A">
-        <computedStyleDescriptions xmi:type="style:EllipseNodeDescription" xmi:id="_dpKVMFs-EeuVkrz0RM5Fbg" borderSizeComputationExpression="1" showIcon="false" labelExpression="A1&#xA;invalid on 2" sizeComputationExpression="[self.name.size()+6/]" labelPosition="node" resizeKind="NSEW">
+        <computedStyleDescriptions xmi:type="style:EllipseNodeDescription" xmi:id="_X8jFwFtAEeu9n_0qzmU-zw" borderSizeComputationExpression="1" showIcon="false" labelExpression="A1&#xA;0 on 2" sizeComputationExpression="[self.name.size()+6/]" labelPosition="node" resizeKind="NSEW">
           <borderColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='dark_blue']"/>
           <labelFormat>bold</labelFormat>
           <labelColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='dark_blue']"/>
           <color xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='white']"/>
         </computedStyleDescriptions>
-        <computedStyleDescriptions xmi:type="style:EllipseNodeDescription" xmi:id="_dpaM0Fs-EeuVkrz0RM5Fbg" borderSizeComputationExpression="1" showIcon="false" labelExpression="A2&#xA;invalid on 4" sizeComputationExpression="[self.name.size()+6/]" labelPosition="node" resizeKind="NSEW">
+        <computedStyleDescriptions xmi:type="style:EllipseNodeDescription" xmi:id="_X8yWUFtAEeu9n_0qzmU-zw" borderSizeComputationExpression="1" showIcon="false" labelExpression="A2&#xA;0 on 4" sizeComputationExpression="[self.name.size()+6/]" labelPosition="node" resizeKind="NSEW">
           <borderColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='dark_blue']"/>
           <labelFormat>bold</labelFormat>
           <labelColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='dark_blue']"/>
           <color xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='white']"/>
         </computedStyleDescriptions>
-        <computedStyleDescriptions xmi:type="style:EdgeStyleDescription" xmi:id="_dqACsFs-EeuVkrz0RM5Fbg" sizeComputationExpression="2" routingStyle="manhattan">
+        <computedStyleDescriptions xmi:type="style:EdgeStyleDescription" xmi:id="_X9aocFtAEeu9n_0qzmU-zw" sizeComputationExpression="2" routingStyle="manhattan">
           <strokeColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='green']"/>
-          <centerLabelStyleDescription xmi:type="style:CenterLabelStyleDescription" xmi:id="_dqACsVs-EeuVkrz0RM5Fbg" labelSize="9" showIcon="false" labelExpression="invalid / 6">
+          <centerLabelStyleDescription xmi:type="style:CenterLabelStyleDescription" xmi:id="_X9aocVtAEeu9n_0qzmU-zw" labelSize="9" showIcon="false" labelExpression="0 / 6">
             <labelColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
           </centerLabelStyleDescription>
         </computedStyleDescriptions>
-        <computedStyleDescriptions xmi:type="style:EdgeStyleDescription" xmi:id="_dqEUIFs-EeuVkrz0RM5Fbg" sizeComputationExpression="2" routingStyle="manhattan">
+        <computedStyleDescriptions xmi:type="style:EdgeStyleDescription" xmi:id="_X9drwFtAEeu9n_0qzmU-zw" sizeComputationExpression="2" routingStyle="manhattan">
           <strokeColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='green']"/>
-          <centerLabelStyleDescription xmi:type="style:CenterLabelStyleDescription" xmi:id="_dqEUIVs-EeuVkrz0RM5Fbg" labelSize="9" showIcon="false" labelExpression="invalid / 1">
+          <centerLabelStyleDescription xmi:type="style:CenterLabelStyleDescription" xmi:id="_X9drwVtAEeu9n_0qzmU-zw" labelSize="9" showIcon="false" labelExpression="0 / 1">
             <labelColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
           </centerLabelStyleDescription>
         </computedStyleDescriptions>
@@ -123,9 +123,9 @@
                 <styles xmi:type="notation:ShapeStyle" xmi:id="_oPW3wmAyEemFMZX_sTS_2A" fontName="Noto Sans" fontHeight="5"/>
                 <layoutConstraint xmi:type="notation:Bounds" xmi:id="_oPW3w2AyEemFMZX_sTS_2A" y="-12" width="48" height="20"/>
               </children>
-              <children xmi:type="notation:Node" xmi:id="_dqjcUFs-EeuVkrz0RM5Fbg" type="3016" element="_dpK8QVs-EeuVkrz0RM5Fbg">
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_dqjcUVs-EeuVkrz0RM5Fbg" fontName="Noto Sans"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dqjcUls-EeuVkrz0RM5Fbg"/>
+              <children xmi:type="notation:Node" xmi:id="_X98z8FtAEeu9n_0qzmU-zw" type="3016" element="_X8js0VtAEeu9n_0qzmU-zw">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_X98z8VtAEeu9n_0qzmU-zw" fontName="Noto Sans"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_X98z8ltAEeu9n_0qzmU-zw"/>
               </children>
               <styles xmi:type="notation:ShapeStyle" xmi:id="_oPT0cWAyEemFMZX_sTS_2A" fontColor="7490599" fontName="Noto Sans" fontHeight="8" bold="true"/>
               <layoutConstraint xmi:type="notation:Bounds" xmi:id="_oPT0cmAyEemFMZX_sTS_2A" x="91" y="42" width="80" height="80"/>
@@ -145,9 +145,9 @@
                 <styles xmi:type="notation:ShapeStyle" xmi:id="_oPaiIWAyEemFMZX_sTS_2A" fontName="Noto Sans" fontHeight="5"/>
                 <layoutConstraint xmi:type="notation:Bounds" xmi:id="_oPaiImAyEemFMZX_sTS_2A" x="-24" y="24" width="32" height="20"/>
               </children>
-              <children xmi:type="notation:Node" xmi:id="_dqkqcFs-EeuVkrz0RM5Fbg" type="3016" element="_dpaz4Vs-EeuVkrz0RM5Fbg">
-                <styles xmi:type="notation:ShapeStyle" xmi:id="_dqkqcVs-EeuVkrz0RM5Fbg" fontName="Noto Sans"/>
-                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_dqkqcls-EeuVkrz0RM5Fbg"/>
+              <children xmi:type="notation:Node" xmi:id="_X9_3QFtAEeu9n_0qzmU-zw" type="3016" element="_X8y9YVtAEeu9n_0qzmU-zw">
+                <styles xmi:type="notation:ShapeStyle" xmi:id="_X9_3QVtAEeu9n_0qzmU-zw" fontName="Noto Sans"/>
+                <layoutConstraint xmi:type="notation:Bounds" xmi:id="_X9_3QltAEeu9n_0qzmU-zw"/>
               </children>
               <styles xmi:type="notation:ShapeStyle" xmi:id="_oPUbgWAyEemFMZX_sTS_2A" fontColor="7490599" fontName="Noto Sans" fontHeight="8" bold="true"/>
               <layoutConstraint xmi:type="notation:Bounds" xmi:id="_oPUbgmAyEemFMZX_sTS_2A" x="343" y="42" width="80" height="80"/>
@@ -329,7 +329,7 @@
         <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']/@defaultLayer/@containerMappings[name='Application']/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']/@defaultLayer/@containerMappings[name='Application']"/>
-      <ownedDiagramElements xmi:type="diagram:DNode" uid="_oOSgzWAyEemFMZX_sTS_2A" name="A1&#xA;invalid on 2" incomingEdges="_oOSg32AyEemFMZX_sTS_2A" width="8" height="8" resizeKind="NSEW">
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_oOSgzWAyEemFMZX_sTS_2A" name="A1&#xA;0 on 2" incomingEdges="_oOSg32AyEemFMZX_sTS_2A" width="8" height="8" resizeKind="NSEW">
         <target xmi:type="sigpml:Agent" href="Simple.sigpml#//@ownedApplication/@ownedAgents.0"/>
         <semanticElements xmi:type="sigpml:Agent" href="Simple.sigpml#//@ownedApplication/@ownedAgents.0"/>
         <ownedBorderedNodes xmi:type="diagram:DNode" uid="_oOSgzmAyEemFMZX_sTS_2A" name="pA1inState" incomingEdges="_oOSg3GAyEemFMZX_sTS_2A" width="2" height="2" resizeKind="NSEW">
@@ -368,12 +368,12 @@
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:Ellipse" uid="_dpK8QVs-EeuVkrz0RM5Fbg" showIcon="false" labelColor="39,76,114" description="_dpKVMFs-EeuVkrz0RM5Fbg" borderSize="1" borderSizeComputationExpression="1" borderColor="39,76,114" labelPosition="node" color="255,255,255">
+        <ownedStyle xmi:type="diagram:Ellipse" uid="_X8js0VtAEeu9n_0qzmU-zw" showIcon="false" labelColor="39,76,114" description="_X8jFwFtAEeu9n_0qzmU-zw" borderSize="1" borderSizeComputationExpression="1" borderColor="39,76,114" labelPosition="node" color="255,255,255">
           <labelFormat>bold</labelFormat>
         </ownedStyle>
         <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']/@defaultLayer/@containerMappings[name='Application']/@subNodeMappings[name='Agent']"/>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNode" uid="_oOSg1WAyEemFMZX_sTS_2A" name="A2&#xA;invalid on 4" incomingEdges="_oOSg4mAyEemFMZX_sTS_2A" width="8" height="8" resizeKind="NSEW">
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_oOSg1WAyEemFMZX_sTS_2A" name="A2&#xA;0 on 4" incomingEdges="_oOSg4mAyEemFMZX_sTS_2A" width="8" height="8" resizeKind="NSEW">
         <target xmi:type="sigpml:Agent" href="Simple.sigpml#//@ownedApplication/@ownedAgents.1"/>
         <semanticElements xmi:type="sigpml:Agent" href="Simple.sigpml#//@ownedApplication/@ownedAgents.1"/>
         <ownedBorderedNodes xmi:type="diagram:DNode" uid="_oOSg1mAyEemFMZX_sTS_2A" name="pA2in" incomingEdges="_oOSg2WAyEemFMZX_sTS_2A" width="2" height="2" resizeKind="NSEW">
@@ -390,25 +390,25 @@
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:Ellipse" uid="_dpaz4Vs-EeuVkrz0RM5Fbg" showIcon="false" labelColor="39,76,114" description="_dpaM0Fs-EeuVkrz0RM5Fbg" borderSize="1" borderSizeComputationExpression="1" borderColor="39,76,114" labelPosition="node" color="255,255,255">
+        <ownedStyle xmi:type="diagram:Ellipse" uid="_X8y9YVtAEeu9n_0qzmU-zw" showIcon="false" labelColor="39,76,114" description="_X8yWUFtAEeu9n_0qzmU-zw" borderSize="1" borderSizeComputationExpression="1" borderColor="39,76,114" labelPosition="node" color="255,255,255">
           <labelFormat>bold</labelFormat>
         </ownedStyle>
         <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']/@defaultLayer/@containerMappings[name='Application']/@subNodeMappings[name='Agent']"/>
       </ownedDiagramElements>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_oOSg2WAyEemFMZX_sTS_2A" name="invalid / 6" incomingEdges="_oOSg62AyEemFMZX_sTS_2A" sourceNode="_oOSg0GAyEemFMZX_sTS_2A" targetNode="_oOSg1mAyEemFMZX_sTS_2A">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_oOSg2WAyEemFMZX_sTS_2A" name="0 / 6" incomingEdges="_oOSg62AyEemFMZX_sTS_2A" sourceNode="_oOSg0GAyEemFMZX_sTS_2A" targetNode="_oOSg1mAyEemFMZX_sTS_2A">
       <target xmi:type="sigpml:Place" href="Simple.sigpml#//@ownedApplication/@ownedPlaces.0"/>
       <semanticElements xmi:type="sigpml:Place" href="Simple.sigpml#//@ownedApplication/@ownedPlaces.0"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_dqACsls-EeuVkrz0RM5Fbg" description="_dqACsFs-EeuVkrz0RM5Fbg" size="2" routingStyle="manhattan" strokeColor="138,226,52">
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_dqACs1s-EeuVkrz0RM5Fbg" labelSize="9" showIcon="false"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_X9aocltAEeu9n_0qzmU-zw" description="_X9aocFtAEeu9n_0qzmU-zw" size="2" routingStyle="manhattan" strokeColor="138,226,52">
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_X9aoc1tAEeu9n_0qzmU-zw" labelSize="9" showIcon="false"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']/@defaultLayer/@edgeMappings[name='Place']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_oOSg3GAyEemFMZX_sTS_2A" name="invalid / 1" sourceNode="_oOSg0mAyEemFMZX_sTS_2A" targetNode="_oOSgzmAyEemFMZX_sTS_2A">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_oOSg3GAyEemFMZX_sTS_2A" name="0 / 1" sourceNode="_oOSg0mAyEemFMZX_sTS_2A" targetNode="_oOSgzmAyEemFMZX_sTS_2A">
       <target xmi:type="sigpml:Place" href="Simple.sigpml#//@ownedApplication/@ownedPlaces.1"/>
       <semanticElements xmi:type="sigpml:Place" href="Simple.sigpml#//@ownedApplication/@ownedPlaces.1"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_dqEUIls-EeuVkrz0RM5Fbg" description="_dqEUIFs-EeuVkrz0RM5Fbg" size="2" routingStyle="manhattan" strokeColor="138,226,52">
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_dqEUI1s-EeuVkrz0RM5Fbg" labelSize="9" showIcon="false"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_X9drwltAEeu9n_0qzmU-zw" description="_X9drwFtAEeu9n_0qzmU-zw" size="2" routingStyle="manhattan" strokeColor="138,226,52">
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_X9drw1tAEeu9n_0qzmU-zw" labelSize="9" showIcon="false"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccmlsigpml.design/description/SigPML.odesign#//@ownedViewpoints[name='SigPML']/@ownedRepresentations[name='SigPML']/@defaultLayer/@edgeMappings[name='Place']"/>
     </ownedDiagramElements>

--- a/examples/moccmlSigPML/modeling_workbench/org.eclipse.gemoc.example.moccmlsigpml.simple_example/launch/debug simple.launch
+++ b/examples/moccmlSigPML/modeling_workbench/org.eclipse.gemoc.example.moccmlsigpml.simple_example/launch/debug simple.launch
@@ -1,17 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.gemoc.execution.concurrent.ccsljavaengine.ui.launcher">
-<booleanAttribute key="Concurrent" value="false"/>
-<booleanAttribute key="Do Exhaustive Simulation" value="false"/>
-<intAttribute key="GEMOC_ANIMATE_DELAY" value="0"/>
-<stringAttribute key="GEMOC_LAUNCH_INITIALIZATION_ARGUMENTS" value=""/>
-<stringAttribute key="GEMOC_LAUNCH_INITIALIZATION_METHOD" value=""/>
-<stringAttribute key="GEMOC_LAUNCH_SELECTED_DECIDER" value="Step by step user decider"/>
-<stringAttribute key="GEMOC_LAUNCH_SELECTED_LANGUAGE" value="xSigPML"/>
-<booleanAttribute key="General" value="false"/>
-<booleanAttribute key="Generic MultiDimensional Trace" value="false"/>
-<booleanAttribute key="MultiBranch Reflective Trace" value="true"/>
-<stringAttribute key="Resource" value="/org.eclipse.gemoc.example.moccmlsigpml.simple_example/Simple.sigpml"/>
-<stringAttribute key="TIMEMODEL_PATH" value=""/>
-<booleanAttribute key="VCD visualization" value="true"/>
-<stringAttribute key="airdResource" value="/org.eclipse.gemoc.example.moccmlsigpml.simple_example/Simple.aird"/>
+    <booleanAttribute key="Concurrent" value="false"/>
+    <booleanAttribute key="Do Exhaustive Simulation" value="false"/>
+    <intAttribute key="GEMOC_ANIMATE_DELAY" value="0"/>
+    <stringAttribute key="GEMOC_LAUNCH_INITIALIZATION_ARGUMENTS" value=""/>
+    <stringAttribute key="GEMOC_LAUNCH_INITIALIZATION_METHOD" value="org.eclipse.gemoc.example.moccmlsigpml.k3dsa.SystemAspect.initializeModel"/>
+    <stringAttribute key="GEMOC_LAUNCH_SELECTED_DECIDER" value="Step by step user decider"/>
+    <stringAttribute key="GEMOC_LAUNCH_SELECTED_LANGUAGE" value="xSigPML"/>
+    <booleanAttribute key="General" value="false"/>
+    <booleanAttribute key="Generic MultiDimensional Data Trace" value="false"/>
+    <booleanAttribute key="Generic MultiDimensional Trace" value="false"/>
+    <booleanAttribute key="MultiBranch Reflective Trace" value="true"/>
+    <stringAttribute key="Resource" value="/org.eclipse.gemoc.example.moccmlsigpml.simple_example/Simple.sigpml"/>
+    <stringAttribute key="TIMEMODEL_PATH" value=""/>
+    <booleanAttribute key="VCD visualization" value="true"/>
+    <stringAttribute key="airdResource" value="/org.eclipse.gemoc.example.moccmlsigpml.simple_example/Simple.aird"/>
+    <booleanAttribute key="fsm MultiDimensional Trace" value="false"/>
+    <booleanAttribute key="org.eclipse.gemoc.trace.gemoc.addon_booleanOption" value="false"/>
 </launchConfiguration>

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.model/model/tfsm.aird
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.model/model/tfsm.aird
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:description="http://www.eclipse.org/sirius/description/1.1.0" xmlns:description_1="http://www.eclipse.org/sirius/diagram/description/1.1.0" xmlns:diagram="http://www.eclipse.org/sirius/diagram/1.1.0" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:style="http://www.eclipse.org/sirius/diagram/description/style/1.1.0" xmlns:viewpoint="http://www.eclipse.org/sirius/1.1.0" xsi:schemaLocation="http://www.eclipse.org/sirius/description/1.1.0 http://www.eclipse.org/sirius/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/style/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description/style">
-  <viewpoint:DAnalysis xmi:id="_uTwMcAH_EeqFPNc_0eQDcQ" selectedViews="_v8xYsAH_EeqFPNc_0eQDcQ" version="13.0.0.201804031646">
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:description="http://www.eclipse.org/sirius/description/1.1.0" xmlns:description_1="http://www.eclipse.org/sirius/diagram/description/1.1.0" xmlns:diagram="http://www.eclipse.org/sirius/diagram/1.1.0" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.3/notation" xmlns:style="http://www.eclipse.org/sirius/diagram/description/style/1.1.0" xmlns:viewpoint="http://www.eclipse.org/sirius/1.1.0" xsi:schemaLocation="http://www.eclipse.org/sirius/description/1.1.0 http://www.eclipse.org/sirius/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/style/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description/style">
+  <viewpoint:DAnalysis uid="_uTwMcAH_EeqFPNc_0eQDcQ" selectedViews="_v8xYsAH_EeqFPNc_0eQDcQ" version="14.3.1.202003261200">
     <semanticResources>tfsm.ecore</semanticResources>
     <semanticResources>http://www.eclipse.org/emf/2002/Ecore</semanticResources>
-    <ownedViews xmi:type="viewpoint:DView" xmi:id="_v8xYsAH_EeqFPNc_0eQDcQ">
+    <ownedViews xmi:type="viewpoint:DView" uid="_v8xYsAH_EeqFPNc_0eQDcQ">
       <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']"/>
-      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" xmi:id="_1nFQIwH_EeqFPNc_0eQDcQ" name="tfsm class diagram" repPath="#_1m97YAH_EeqFPNc_0eQDcQ">
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_1nFQIwH_EeqFPNc_0eQDcQ" name="tfsm class diagram" repPath="#_1nEpEAH_EeqFPNc_0eQDcQ" changeId="4317ab29-4ff6-4a98-a3cd-c4608417faa5">
         <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']"/>
         <target xmi:type="ecore:EPackage" href="tfsm.ecore#/"/>
       </ownedRepresentationDescriptors>
     </ownedViews>
   </viewpoint:DAnalysis>
-  <diagram:DSemanticDiagram xmi:id="_1nEpEAH_EeqFPNc_0eQDcQ" name="tfsm class diagram" uid="_1m97YAH_EeqFPNc_0eQDcQ">
-    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" xmi:id="_1nEpEQH_EeqFPNc_0eQDcQ" source="DANNOTATION_CUSTOMIZATION_KEY">
-      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" xmi:id="_1nEpEgH_EeqFPNc_0eQDcQ">
+  <diagram:DSemanticDiagram uid="_1nEpEAH_EeqFPNc_0eQDcQ">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_1nEpEQH_EeqFPNc_0eQDcQ" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_1nEpEgH_EeqFPNc_0eQDcQ">
         <computedStyleDescriptions xmi:type="style:BundledImageDescription" xmi:id="_192KUQH_EeqFPNc_0eQDcQ" labelExpression="service:render" labelAlignment="LEFT" tooltipExpression="service:renderTooltip" sizeComputationExpression="1">
           <borderColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
           <labelFormat>bold</labelFormat>
@@ -58,9 +58,15 @@
             <labelColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
           </endLabelStyleDescription>
         </computedStyleDescriptions>
+        <computedStyleDescriptions xmi:type="style:BundledImageDescription" xmi:id="_TWeSgltAEeuk8NiEvxa5og" labelExpression="service:renderAsNode" labelAlignment="LEFT" tooltipExpression="service:renderTooltip" sizeComputationExpression="1">
+          <borderColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+          <labelFormat>bold</labelFormat>
+          <labelColor xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='black']"/>
+          <color xmi:type="description:SystemColor" href="environment:/viewpoint#//@systemColors/@entries[name='blue']"/>
+        </computedStyleDescriptions>
       </data>
     </ownedAnnotationEntries>
-    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" xmi:id="_1nGeQAH_EeqFPNc_0eQDcQ" source="GMF_DIAGRAMS">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_1nGeQAH_EeqFPNc_0eQDcQ" source="GMF_DIAGRAMS">
       <data xmi:type="notation:Diagram" xmi:id="_1nGeQQH_EeqFPNc_0eQDcQ" type="Sirius" element="_1nEpEAH_EeqFPNc_0eQDcQ" measurementUnit="Pixel">
         <children xmi:type="notation:Node" xmi:id="_1-LhgAH_EeqFPNc_0eQDcQ" type="2003" element="_19ioUAH_EeqFPNc_0eQDcQ">
           <children xmi:type="notation:Node" xmi:id="_1-MIkAH_EeqFPNc_0eQDcQ" type="5007"/>
@@ -95,13 +101,13 @@
         <children xmi:type="notation:Node" xmi:id="_1-MvoAH_EeqFPNc_0eQDcQ" type="2003" element="_19lEkQH_EeqFPNc_0eQDcQ">
           <children xmi:type="notation:Node" xmi:id="_1-MvowH_EeqFPNc_0eQDcQ" type="5007"/>
           <children xmi:type="notation:Node" xmi:id="_1-MvpAH_EeqFPNc_0eQDcQ" type="7004">
-            <children xmi:type="notation:Node" xmi:id="_1-SPMAH_EeqFPNc_0eQDcQ" type="3010" element="_1908MQH_EeqFPNc_0eQDcQ">
-              <styles xmi:type="notation:FontStyle" xmi:id="_1-SPMQH_EeqFPNc_0eQDcQ" fontName="Ubuntu" fontHeight="8"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_1-SPMgH_EeqFPNc_0eQDcQ"/>
-            </children>
             <children xmi:type="notation:Node" xmi:id="_1-SPMwH_EeqFPNc_0eQDcQ" type="3010" element="_191jQQH_EeqFPNc_0eQDcQ">
               <styles xmi:type="notation:FontStyle" xmi:id="_1-SPNAH_EeqFPNc_0eQDcQ" fontName="Ubuntu" fontHeight="8"/>
               <layoutConstraint xmi:type="notation:Location" xmi:id="_1-SPNQH_EeqFPNc_0eQDcQ"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_TWybkFtAEeuk8NiEvxa5og" type="3010" element="_TWYy8VtAEeuk8NiEvxa5og">
+              <styles xmi:type="notation:FontStyle" xmi:id="_TWybkVtAEeuk8NiEvxa5og" fontName="Noto Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_TWybkltAEeuk8NiEvxa5og"/>
             </children>
             <styles xmi:type="notation:SortingStyle" xmi:id="_1-MvpQH_EeqFPNc_0eQDcQ"/>
             <styles xmi:type="notation:FilteringStyle" xmi:id="_1-MvpgH_EeqFPNc_0eQDcQ"/>
@@ -186,6 +192,10 @@
               <styles xmi:type="notation:FontStyle" xmi:id="_1-TdVAH_EeqFPNc_0eQDcQ" fontName="Ubuntu" fontHeight="8"/>
               <layoutConstraint xmi:type="notation:Location" xmi:id="_1-TdVQH_EeqFPNc_0eQDcQ"/>
             </children>
+            <children xmi:type="notation:Node" xmi:id="_TW0QwFtAEeuk8NiEvxa5og" type="3010" element="_TWdEYltAEeuk8NiEvxa5og">
+              <styles xmi:type="notation:FontStyle" xmi:id="_TW0QwVtAEeuk8NiEvxa5og" fontName="Noto Sans" fontHeight="8"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_TW0QwltAEeuk8NiEvxa5og"/>
+            </children>
             <styles xmi:type="notation:SortingStyle" xmi:id="_1-QaBQH_EeqFPNc_0eQDcQ"/>
             <styles xmi:type="notation:FilteringStyle" xmi:id="_1-QaBgH_EeqFPNc_0eQDcQ"/>
           </children>
@@ -195,13 +205,13 @@
         <children xmi:type="notation:Node" xmi:id="_1-QaBwH_EeqFPNc_0eQDcQ" type="2003" element="_19tncAH_EeqFPNc_0eQDcQ">
           <children xmi:type="notation:Node" xmi:id="_1-RBEAH_EeqFPNc_0eQDcQ" type="5007"/>
           <children xmi:type="notation:Node" xmi:id="_1-RBEQH_EeqFPNc_0eQDcQ" type="7004">
-            <children xmi:type="notation:Node" xmi:id="_1-TdVgH_EeqFPNc_0eQDcQ" type="3010" element="_195NoQH_EeqFPNc_0eQDcQ">
-              <styles xmi:type="notation:FontStyle" xmi:id="_1-TdVwH_EeqFPNc_0eQDcQ" fontName="Ubuntu" fontHeight="8"/>
-              <layoutConstraint xmi:type="notation:Location" xmi:id="_1-TdWAH_EeqFPNc_0eQDcQ"/>
-            </children>
             <children xmi:type="notation:Node" xmi:id="_1-TdWQH_EeqFPNc_0eQDcQ" type="3010" element="_196bwAH_EeqFPNc_0eQDcQ">
               <styles xmi:type="notation:FontStyle" xmi:id="_1-TdWgH_EeqFPNc_0eQDcQ" fontName="Ubuntu" fontHeight="8"/>
               <layoutConstraint xmi:type="notation:Location" xmi:id="_1-TdWwH_EeqFPNc_0eQDcQ"/>
+            </children>
+            <children xmi:type="notation:Node" xmi:id="_TW0Qw1tAEeuk8NiEvxa5og" type="3010" element="_TWeSgVtAEeuk8NiEvxa5og">
+              <styles xmi:type="notation:FontStyle" xmi:id="_TW0QxFtAEeuk8NiEvxa5og" fontName="Noto Sans" fontHeight="8" bold="true"/>
+              <layoutConstraint xmi:type="notation:Location" xmi:id="_TW0QxVtAEeuk8NiEvxa5og"/>
             </children>
             <styles xmi:type="notation:SortingStyle" xmi:id="_1-RBEgH_EeqFPNc_0eQDcQ"/>
             <styles xmi:type="notation:FilteringStyle" xmi:id="_1-RBEwH_EeqFPNc_0eQDcQ"/>
@@ -611,536 +621,544 @@
         </edges>
       </data>
     </ownedAnnotationEntries>
-    <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_19ioUAH_EeqFPNc_0eQDcQ" name="TFSM" tooltipText="" outgoingEdges="_197p4AH_EeqFPNc_0eQDcQ _198Q9gH_EeqFPNc_0eQDcQ _1984BgH_EeqFPNc_0eQDcQ _199fFgH_EeqFPNc_0eQDcQ _1-DlsAH_EeqFPNc_0eQDcQ _1-JFQAH_EeqFPNc_0eQDcQ" incomingEdges="_1-BJcwH_EeqFPNc_0eQDcQ" width="12" height="10">
+    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_19ioUAH_EeqFPNc_0eQDcQ" name="TFSM" tooltipText="" outgoingEdges="_197p4AH_EeqFPNc_0eQDcQ _198Q9gH_EeqFPNc_0eQDcQ _1984BgH_EeqFPNc_0eQDcQ _199fFgH_EeqFPNc_0eQDcQ _1-DlsAH_EeqFPNc_0eQDcQ _1-JFQAH_EeqFPNc_0eQDcQ" incomingEdges="_1-BJcwH_EeqFPNc_0eQDcQ" width="12" height="10">
       <target xmi:type="ecore:EClass" href="tfsm.ecore#//TFSM"/>
       <semanticElements xmi:type="ecore:EClass" href="tfsm.ecore#//TFSM"/>
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
       <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
       <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-      <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_19j2cAH_EeqFPNc_0eQDcQ" borderSize="1" borderSizeComputationExpression="1" backgroundStyle="Liquid" foregroundColor="255,252,216">
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_19j2cAH_EeqFPNc_0eQDcQ" borderSize="1" borderSizeComputationExpression="1" backgroundStyle="Liquid" foregroundColor="255,252,216">
         <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']"/>
-      <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_19zuEAH_EeqFPNc_0eQDcQ" name="initialize()" tooltipText="initialize()">
+      <ownedElements xmi:type="diagram:DNodeListElement" uid="_19zuEAH_EeqFPNc_0eQDcQ" name="initialize()" tooltipText="initialize()">
         <target xmi:type="ecore:EOperation" href="tfsm.ecore#//TFSM/initialize"/>
         <semanticElements xmi:type="ecore:EOperation" href="tfsm.ecore#//TFSM/initialize"/>
-        <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_19zuEQH_EeqFPNc_0eQDcQ" labelAlignment="LEFT">
+        <ownedStyle xmi:type="diagram:BundledImage" uid="_19zuEQH_EeqFPNc_0eQDcQ" labelAlignment="LEFT">
           <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@subNodeMappings[name='Operation']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@subNodeMappings[name='Operation']"/>
       </ownedElements>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_19kdgAH_EeqFPNc_0eQDcQ" name="State" tooltipText="" outgoingEdges="_1-EMwwH_EeqFPNc_0eQDcQ _1-IeMAH_EeqFPNc_0eQDcQ _1-JsUAH_EeqFPNc_0eQDcQ" incomingEdges="_197p4AH_EeqFPNc_0eQDcQ _1-JFQAH_EeqFPNc_0eQDcQ" width="12" height="10">
+    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_19kdgAH_EeqFPNc_0eQDcQ" name="State" tooltipText="" outgoingEdges="_1-EMwwH_EeqFPNc_0eQDcQ _1-IeMAH_EeqFPNc_0eQDcQ _1-JsUAH_EeqFPNc_0eQDcQ" incomingEdges="_197p4AH_EeqFPNc_0eQDcQ _1-JFQAH_EeqFPNc_0eQDcQ" width="12" height="10">
       <target xmi:type="ecore:EClass" href="tfsm.ecore#//State"/>
       <semanticElements xmi:type="ecore:EClass" href="tfsm.ecore#//State"/>
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
       <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
       <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-      <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_19lEkAH_EeqFPNc_0eQDcQ" borderSize="1" borderSizeComputationExpression="1" backgroundStyle="Liquid" foregroundColor="255,252,216">
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_19lEkAH_EeqFPNc_0eQDcQ" borderSize="1" borderSizeComputationExpression="1" backgroundStyle="Liquid" foregroundColor="255,252,216">
         <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']"/>
-      <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_190VIAH_EeqFPNc_0eQDcQ" name="onEnter()" tooltipText="onEnter()">
+      <ownedElements xmi:type="diagram:DNodeListElement" uid="_190VIAH_EeqFPNc_0eQDcQ" name="onEnter()" tooltipText="onEnter()">
         <target xmi:type="ecore:EOperation" href="tfsm.ecore#//State/onEnter"/>
         <semanticElements xmi:type="ecore:EOperation" href="tfsm.ecore#//State/onEnter"/>
-        <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_190VIQH_EeqFPNc_0eQDcQ" labelAlignment="LEFT">
+        <ownedStyle xmi:type="diagram:BundledImage" uid="_190VIQH_EeqFPNc_0eQDcQ" labelAlignment="LEFT">
           <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@subNodeMappings[name='Operation']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@subNodeMappings[name='Operation']"/>
       </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_190VIgH_EeqFPNc_0eQDcQ" name="onLeave()" tooltipText="onLeave()">
+      <ownedElements xmi:type="diagram:DNodeListElement" uid="_190VIgH_EeqFPNc_0eQDcQ" name="onLeave()" tooltipText="onLeave()">
         <target xmi:type="ecore:EOperation" href="tfsm.ecore#//State/onLeave"/>
         <semanticElements xmi:type="ecore:EOperation" href="tfsm.ecore#//State/onLeave"/>
-        <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_1908MAH_EeqFPNc_0eQDcQ" labelAlignment="LEFT">
+        <ownedStyle xmi:type="diagram:BundledImage" uid="_1908MAH_EeqFPNc_0eQDcQ" labelAlignment="LEFT">
           <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@subNodeMappings[name='Operation']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@subNodeMappings[name='Operation']"/>
       </ownedElements>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_19lEkQH_EeqFPNc_0eQDcQ" name="Transition" tooltipText="" outgoingEdges="_19-GIwH_EeqFPNc_0eQDcQ _19-tMwH_EeqFPNc_0eQDcQ _1-Ez0wH_EeqFPNc_0eQDcQ" incomingEdges="_199fFgH_EeqFPNc_0eQDcQ _1-AiYwH_EeqFPNc_0eQDcQ _1-IeMAH_EeqFPNc_0eQDcQ _1-JsUAH_EeqFPNc_0eQDcQ" width="12" height="10">
+    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_19lEkQH_EeqFPNc_0eQDcQ" name="Transition" tooltipText="" outgoingEdges="_19-GIwH_EeqFPNc_0eQDcQ _19-tMwH_EeqFPNc_0eQDcQ _1-Ez0wH_EeqFPNc_0eQDcQ" incomingEdges="_199fFgH_EeqFPNc_0eQDcQ _1-AiYwH_EeqFPNc_0eQDcQ _1-IeMAH_EeqFPNc_0eQDcQ _1-JsUAH_EeqFPNc_0eQDcQ" width="12" height="10">
       <target xmi:type="ecore:EClass" href="tfsm.ecore#//Transition"/>
       <semanticElements xmi:type="ecore:EClass" href="tfsm.ecore#//Transition"/>
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
       <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
       <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-      <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_19lroAH_EeqFPNc_0eQDcQ" borderSize="1" borderSizeComputationExpression="1" backgroundStyle="Liquid" foregroundColor="255,252,216">
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_19lroAH_EeqFPNc_0eQDcQ" borderSize="1" borderSizeComputationExpression="1" backgroundStyle="Liquid" foregroundColor="255,252,216">
         <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']"/>
-      <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_1908MQH_EeqFPNc_0eQDcQ" name="action : EString" tooltipText="">
-        <target xmi:type="ecore:EAttribute" href="tfsm.ecore#//Transition/action"/>
-        <semanticElements xmi:type="ecore:EAttribute" href="tfsm.ecore#//Transition/action"/>
-        <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_191jQAH_EeqFPNc_0eQDcQ" labelAlignment="LEFT">
-          <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@subNodeMappings[name='EC%20EAttribute']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@subNodeMappings[name='EC%20EAttribute']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_191jQQH_EeqFPNc_0eQDcQ" name="fire()" tooltipText="fire()">
+      <ownedElements xmi:type="diagram:DNodeListElement" uid="_191jQQH_EeqFPNc_0eQDcQ" name="fire()" tooltipText="fire()">
         <target xmi:type="ecore:EOperation" href="tfsm.ecore#//Transition/fire"/>
         <semanticElements xmi:type="ecore:EOperation" href="tfsm.ecore#//Transition/fire"/>
-        <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_191jQgH_EeqFPNc_0eQDcQ" labelAlignment="LEFT">
+        <ownedStyle xmi:type="diagram:BundledImage" uid="_191jQgH_EeqFPNc_0eQDcQ" labelAlignment="LEFT">
           <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@subNodeMappings[name='Operation']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@subNodeMappings[name='Operation']"/>
       </ownedElements>
+      <ownedElements xmi:type="diagram:DNodeListElement" uid="_TWYy8VtAEeuk8NiEvxa5og" name=" action : IntegerCalculationExpression" tooltipText="">
+        <target xmi:type="ecore:EReference" href="tfsm.ecore#//Transition/action"/>
+        <semanticElements xmi:type="ecore:EReference" href="tfsm.ecore#//Transition/action"/>
+        <ownedStyle xmi:type="diagram:BundledImage" uid="_TWaoIFtAEeuk8NiEvxa5og" labelAlignment="LEFT" color="114,159,207">
+          <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@subNodeMappings[name='EC%20EReferenceNode']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@subNodeMappings[name='EC%20EReferenceNode']"/>
+      </ownedElements>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_19mSsAH_EeqFPNc_0eQDcQ" name="NamedElement" tooltipText="" incomingEdges="_1-DlsAH_EeqFPNc_0eQDcQ _1-EMwwH_EeqFPNc_0eQDcQ _1-Ez0wH_EeqFPNc_0eQDcQ _1-Fa4AH_EeqFPNc_0eQDcQ _1-GpAAH_EeqFPNc_0eQDcQ _1-GpBAH_EeqFPNc_0eQDcQ _1-HQEwH_EeqFPNc_0eQDcQ" width="12" height="10">
+    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_19mSsAH_EeqFPNc_0eQDcQ" name="NamedElement" tooltipText="" incomingEdges="_1-DlsAH_EeqFPNc_0eQDcQ _1-EMwwH_EeqFPNc_0eQDcQ _1-Ez0wH_EeqFPNc_0eQDcQ _1-Fa4AH_EeqFPNc_0eQDcQ _1-GpAAH_EeqFPNc_0eQDcQ _1-GpBAH_EeqFPNc_0eQDcQ _1-HQEwH_EeqFPNc_0eQDcQ" width="12" height="10">
       <target xmi:type="ecore:EClass" href="tfsm.ecore#//NamedElement"/>
       <semanticElements xmi:type="ecore:EClass" href="tfsm.ecore#//NamedElement"/>
-      <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_19m5wAH_EeqFPNc_0eQDcQ" iconPath="/org.eclipse.emf.ecoretools.design/icons/full/obj16/EClass_abstract.gif" borderSize="1" borderSizeComputationExpression="1" borderColor="125,125,125" backgroundStyle="Liquid" foregroundColor="228,228,228">
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_19m5wAH_EeqFPNc_0eQDcQ" iconPath="/org.eclipse.emf.ecoretools.design/icons/full/obj16/EClass_abstract.gif" borderSize="1" borderSizeComputationExpression="1" borderColor="125,125,125" backgroundStyle="Liquid" foregroundColor="228,228,228">
         <labelFormat>italic</labelFormat>
         <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@conditionnalStyles.1/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']"/>
-      <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_192KUAH_EeqFPNc_0eQDcQ" name="name : EString" tooltipText="">
+      <ownedElements xmi:type="diagram:DNodeListElement" uid="_192KUAH_EeqFPNc_0eQDcQ" name="name : EString" tooltipText="">
         <target xmi:type="ecore:EAttribute" href="tfsm.ecore#//NamedElement/name"/>
         <semanticElements xmi:type="ecore:EAttribute" href="tfsm.ecore#//NamedElement/name"/>
-        <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_192xYAH_EeqFPNc_0eQDcQ" labelAlignment="LEFT" description="_192KUQH_EeqFPNc_0eQDcQ">
+        <ownedStyle xmi:type="diagram:BundledImage" uid="_192xYAH_EeqFPNc_0eQDcQ" labelAlignment="LEFT" description="_192KUQH_EeqFPNc_0eQDcQ">
           <labelFormat>bold</labelFormat>
         </ownedStyle>
         <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@subNodeMappings[name='EC%20EAttribute']"/>
       </ownedElements>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_19ng0AH_EeqFPNc_0eQDcQ" name="Guard" tooltipText="" outgoingEdges="_1-Fa4AH_EeqFPNc_0eQDcQ" incomingEdges="_19-GIwH_EeqFPNc_0eQDcQ _1-Fa5AH_EeqFPNc_0eQDcQ _1-GB8wH_EeqFPNc_0eQDcQ _1-H3IAH_EeqFPNc_0eQDcQ" width="12" height="10">
+    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_19ng0AH_EeqFPNc_0eQDcQ" name="Guard" tooltipText="" outgoingEdges="_1-Fa4AH_EeqFPNc_0eQDcQ" incomingEdges="_19-GIwH_EeqFPNc_0eQDcQ _1-Fa5AH_EeqFPNc_0eQDcQ _1-GB8wH_EeqFPNc_0eQDcQ _1-H3IAH_EeqFPNc_0eQDcQ" width="12" height="10">
       <target xmi:type="ecore:EClass" href="tfsm.ecore#//Guard"/>
       <semanticElements xmi:type="ecore:EClass" href="tfsm.ecore#//Guard"/>
-      <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_19oH4AH_EeqFPNc_0eQDcQ" iconPath="/org.eclipse.emf.ecoretools.design/icons/full/obj16/EClass_abstract.gif" borderSize="1" borderSizeComputationExpression="1" borderColor="125,125,125" backgroundStyle="Liquid" foregroundColor="228,228,228">
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_19oH4AH_EeqFPNc_0eQDcQ" iconPath="/org.eclipse.emf.ecoretools.design/icons/full/obj16/EClass_abstract.gif" borderSize="1" borderSizeComputationExpression="1" borderColor="125,125,125" backgroundStyle="Liquid" foregroundColor="228,228,228">
         <labelFormat>italic</labelFormat>
         <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@conditionnalStyles.1/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_19pWAAH_EeqFPNc_0eQDcQ" name="TemporalGuard" tooltipText="" outgoingEdges="_19_UQwH_EeqFPNc_0eQDcQ _1-Fa5AH_EeqFPNc_0eQDcQ" width="12" height="10">
+    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_19pWAAH_EeqFPNc_0eQDcQ" name="TemporalGuard" tooltipText="" outgoingEdges="_19_UQwH_EeqFPNc_0eQDcQ _1-Fa5AH_EeqFPNc_0eQDcQ" width="12" height="10">
       <target xmi:type="ecore:EClass" href="tfsm.ecore#//TemporalGuard"/>
       <semanticElements xmi:type="ecore:EClass" href="tfsm.ecore#//TemporalGuard"/>
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
       <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
       <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-      <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_19pWAQH_EeqFPNc_0eQDcQ" borderSize="1" borderSizeComputationExpression="1" backgroundStyle="Liquid" foregroundColor="255,252,216">
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_19pWAQH_EeqFPNc_0eQDcQ" borderSize="1" borderSizeComputationExpression="1" backgroundStyle="Liquid" foregroundColor="255,252,216">
         <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']"/>
-      <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_192xYQH_EeqFPNc_0eQDcQ" name="afterDuration : EInt" tooltipText="">
+      <ownedElements xmi:type="diagram:DNodeListElement" uid="_192xYQH_EeqFPNc_0eQDcQ" name="afterDuration : EInt" tooltipText="">
         <target xmi:type="ecore:EAttribute" href="tfsm.ecore#//TemporalGuard/afterDuration"/>
         <semanticElements xmi:type="ecore:EAttribute" href="tfsm.ecore#//TemporalGuard/afterDuration"/>
-        <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_193YcAH_EeqFPNc_0eQDcQ" labelAlignment="LEFT" description="_192KUQH_EeqFPNc_0eQDcQ">
+        <ownedStyle xmi:type="diagram:BundledImage" uid="_193YcAH_EeqFPNc_0eQDcQ" labelAlignment="LEFT" description="_192KUQH_EeqFPNc_0eQDcQ">
           <labelFormat>bold</labelFormat>
         </ownedStyle>
         <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@subNodeMappings[name='EC%20EAttribute']"/>
       </ownedElements>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_19p9EAH_EeqFPNc_0eQDcQ" name="EventGuard" tooltipText="" outgoingEdges="_19_7UwH_EeqFPNc_0eQDcQ _1-GB8wH_EeqFPNc_0eQDcQ" width="12" height="10">
+    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_19p9EAH_EeqFPNc_0eQDcQ" name="EventGuard" tooltipText="" outgoingEdges="_19_7UwH_EeqFPNc_0eQDcQ _1-GB8wH_EeqFPNc_0eQDcQ" width="12" height="10">
       <target xmi:type="ecore:EClass" href="tfsm.ecore#//EventGuard"/>
       <semanticElements xmi:type="ecore:EClass" href="tfsm.ecore#//EventGuard"/>
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
       <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
       <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-      <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_19qkIAH_EeqFPNc_0eQDcQ" borderSize="1" borderSizeComputationExpression="1" backgroundStyle="Liquid" foregroundColor="255,252,216">
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_19qkIAH_EeqFPNc_0eQDcQ" borderSize="1" borderSizeComputationExpression="1" backgroundStyle="Liquid" foregroundColor="255,252,216">
         <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_19qkIQH_EeqFPNc_0eQDcQ" name="FSMEvent" tooltipText="" outgoingEdges="_1-AiYwH_EeqFPNc_0eQDcQ _1-GpAAH_EeqFPNc_0eQDcQ" incomingEdges="_198Q9gH_EeqFPNc_0eQDcQ _19-tMwH_EeqFPNc_0eQDcQ _19_7UwH_EeqFPNc_0eQDcQ _1-CXkwH_EeqFPNc_0eQDcQ" width="12" height="10">
+    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_19qkIQH_EeqFPNc_0eQDcQ" name="FSMEvent" tooltipText="" outgoingEdges="_1-AiYwH_EeqFPNc_0eQDcQ _1-GpAAH_EeqFPNc_0eQDcQ" incomingEdges="_198Q9gH_EeqFPNc_0eQDcQ _19-tMwH_EeqFPNc_0eQDcQ _19_7UwH_EeqFPNc_0eQDcQ _1-CXkwH_EeqFPNc_0eQDcQ" width="12" height="10">
       <target xmi:type="ecore:EClass" href="tfsm.ecore#//FSMEvent"/>
       <semanticElements xmi:type="ecore:EClass" href="tfsm.ecore#//FSMEvent"/>
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
       <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
       <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-      <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_19rLMAH_EeqFPNc_0eQDcQ" borderSize="1" borderSizeComputationExpression="1" backgroundStyle="Liquid" foregroundColor="255,252,216">
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_19rLMAH_EeqFPNc_0eQDcQ" borderSize="1" borderSizeComputationExpression="1" backgroundStyle="Liquid" foregroundColor="255,252,216">
         <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']"/>
-      <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_193_gAH_EeqFPNc_0eQDcQ" name="occurs()" tooltipText="occurs()">
+      <ownedElements xmi:type="diagram:DNodeListElement" uid="_193_gAH_EeqFPNc_0eQDcQ" name="occurs()" tooltipText="occurs()">
         <target xmi:type="ecore:EOperation" href="tfsm.ecore#//FSMEvent/occurs"/>
         <semanticElements xmi:type="ecore:EOperation" href="tfsm.ecore#//FSMEvent/occurs"/>
-        <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_193_gQH_EeqFPNc_0eQDcQ" labelAlignment="LEFT">
+        <ownedStyle xmi:type="diagram:BundledImage" uid="_193_gQH_EeqFPNc_0eQDcQ" labelAlignment="LEFT">
           <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@subNodeMappings[name='Operation']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@subNodeMappings[name='Operation']"/>
       </ownedElements>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_19ryQAH_EeqFPNc_0eQDcQ" name="FSMClock" tooltipText="" outgoingEdges="_1-GpBAH_EeqFPNc_0eQDcQ" incomingEdges="_1984BgH_EeqFPNc_0eQDcQ _19_UQwH_EeqFPNc_0eQDcQ _1-BwgwH_EeqFPNc_0eQDcQ" width="12" height="10">
+    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_19ryQAH_EeqFPNc_0eQDcQ" name="FSMClock" tooltipText="" outgoingEdges="_1-GpBAH_EeqFPNc_0eQDcQ" incomingEdges="_1984BgH_EeqFPNc_0eQDcQ _19_UQwH_EeqFPNc_0eQDcQ _1-BwgwH_EeqFPNc_0eQDcQ" width="12" height="10">
       <target xmi:type="ecore:EClass" href="tfsm.ecore#//FSMClock"/>
       <semanticElements xmi:type="ecore:EClass" href="tfsm.ecore#//FSMClock"/>
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
       <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
       <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-      <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_19sZUAH_EeqFPNc_0eQDcQ" borderSize="1" borderSizeComputationExpression="1" backgroundStyle="Liquid" foregroundColor="255,252,216">
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_19sZUAH_EeqFPNc_0eQDcQ" borderSize="1" borderSizeComputationExpression="1" backgroundStyle="Liquid" foregroundColor="255,252,216">
         <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']"/>
-      <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_193_ggH_EeqFPNc_0eQDcQ" name="ticks()" tooltipText="ticks()">
+      <ownedElements xmi:type="diagram:DNodeListElement" uid="_193_ggH_EeqFPNc_0eQDcQ" name="ticks()" tooltipText="ticks()">
         <target xmi:type="ecore:EOperation" href="tfsm.ecore#//FSMClock/ticks"/>
         <semanticElements xmi:type="ecore:EOperation" href="tfsm.ecore#//FSMClock/ticks"/>
-        <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_194mkAH_EeqFPNc_0eQDcQ" labelAlignment="LEFT">
+        <ownedStyle xmi:type="diagram:BundledImage" uid="_194mkAH_EeqFPNc_0eQDcQ" labelAlignment="LEFT">
           <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@subNodeMappings[name='Operation']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@subNodeMappings[name='Operation']"/>
       </ownedElements>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_19tAYAH_EeqFPNc_0eQDcQ" name="TimedSystem" tooltipText="" outgoingEdges="_1-BJcwH_EeqFPNc_0eQDcQ _1-BwgwH_EeqFPNc_0eQDcQ _1-CXkwH_EeqFPNc_0eQDcQ _1-HQEwH_EeqFPNc_0eQDcQ" width="12" height="10">
+    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_19tAYAH_EeqFPNc_0eQDcQ" name="TimedSystem" tooltipText="" outgoingEdges="_1-BJcwH_EeqFPNc_0eQDcQ _1-BwgwH_EeqFPNc_0eQDcQ _1-CXkwH_EeqFPNc_0eQDcQ _1-HQEwH_EeqFPNc_0eQDcQ" width="12" height="10">
       <target xmi:type="ecore:EClass" href="tfsm.ecore#//TimedSystem"/>
       <semanticElements xmi:type="ecore:EClass" href="tfsm.ecore#//TimedSystem"/>
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
       <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
       <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-      <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_19tAYQH_EeqFPNc_0eQDcQ" borderSize="1" borderSizeComputationExpression="1" backgroundStyle="Liquid" foregroundColor="255,252,216">
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_19tAYQH_EeqFPNc_0eQDcQ" borderSize="1" borderSizeComputationExpression="1" backgroundStyle="Liquid" foregroundColor="255,252,216">
         <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']"/>
-      <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_194mkQH_EeqFPNc_0eQDcQ" name="initialize()" tooltipText="initialize()">
+      <ownedElements xmi:type="diagram:DNodeListElement" uid="_194mkQH_EeqFPNc_0eQDcQ" name="initialize()" tooltipText="initialize()">
         <target xmi:type="ecore:EOperation" href="tfsm.ecore#//TimedSystem/initialize"/>
         <semanticElements xmi:type="ecore:EOperation" href="tfsm.ecore#//TimedSystem/initialize"/>
-        <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_195NoAH_EeqFPNc_0eQDcQ" labelAlignment="LEFT">
+        <ownedStyle xmi:type="diagram:BundledImage" uid="_195NoAH_EeqFPNc_0eQDcQ" labelAlignment="LEFT">
           <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@subNodeMappings[name='Operation']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@subNodeMappings[name='Operation']"/>
       </ownedElements>
+      <ownedElements xmi:type="diagram:DNodeListElement" uid="_TWdEYltAEeuk8NiEvxa5og" name=" ownedVars : Variable" tooltipText="">
+        <target xmi:type="ecore:EReference" href="tfsm.ecore#//TimedSystem/ownedVars"/>
+        <semanticElements xmi:type="ecore:EReference" href="tfsm.ecore#//TimedSystem/ownedVars"/>
+        <ownedStyle xmi:type="diagram:BundledImage" uid="_TWdrcFtAEeuk8NiEvxa5og" labelAlignment="LEFT" color="114,159,207">
+          <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@subNodeMappings[name='EC%20EReferenceNode']/@style"/>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@subNodeMappings[name='EC%20EReferenceNode']"/>
+      </ownedElements>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNodeList" xmi:id="_19tncAH_EeqFPNc_0eQDcQ" name="EvaluateGuard" tooltipText="" outgoingEdges="_1-H3IAH_EeqFPNc_0eQDcQ" width="12" height="10">
+    <ownedDiagramElements xmi:type="diagram:DNodeList" uid="_19tncAH_EeqFPNc_0eQDcQ" name="EvaluateGuard" tooltipText="" outgoingEdges="_1-H3IAH_EeqFPNc_0eQDcQ" width="12" height="10">
       <target xmi:type="ecore:EClass" href="tfsm.ecore#//EvaluateGuard"/>
       <semanticElements xmi:type="ecore:EClass" href="tfsm.ecore#//EvaluateGuard"/>
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
       <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
       <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-      <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_19uOgAH_EeqFPNc_0eQDcQ" borderSize="1" borderSizeComputationExpression="1" backgroundStyle="Liquid" foregroundColor="255,252,216">
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_19uOgAH_EeqFPNc_0eQDcQ" borderSize="1" borderSizeComputationExpression="1" backgroundStyle="Liquid" foregroundColor="255,252,216">
         <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']"/>
-      <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_195NoQH_EeqFPNc_0eQDcQ" name="condition : EString" tooltipText="">
-        <target xmi:type="ecore:EAttribute" href="tfsm.ecore#//EvaluateGuard/condition"/>
-        <semanticElements xmi:type="ecore:EAttribute" href="tfsm.ecore#//EvaluateGuard/condition"/>
-        <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_1950sAH_EeqFPNc_0eQDcQ" labelAlignment="LEFT">
-          <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@subNodeMappings[name='EC%20EAttribute']/@style"/>
-        </ownedStyle>
-        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@subNodeMappings[name='EC%20EAttribute']"/>
-      </ownedElements>
-      <ownedElements xmi:type="diagram:DNodeListElement" xmi:id="_196bwAH_EeqFPNc_0eQDcQ" name="evaluate() : EBoolean" tooltipText="evaluate() : EBoolean">
+      <ownedElements xmi:type="diagram:DNodeListElement" uid="_196bwAH_EeqFPNc_0eQDcQ" name="evaluate() : EBoolean" tooltipText="evaluate() : EBoolean">
         <target xmi:type="ecore:EOperation" href="tfsm.ecore#//EvaluateGuard/evaluate"/>
         <semanticElements xmi:type="ecore:EOperation" href="tfsm.ecore#//EvaluateGuard/evaluate"/>
-        <ownedStyle xmi:type="diagram:BundledImage" xmi:id="_196bwQH_EeqFPNc_0eQDcQ" labelAlignment="LEFT">
+        <ownedStyle xmi:type="diagram:BundledImage" uid="_196bwQH_EeqFPNc_0eQDcQ" labelAlignment="LEFT">
           <description xmi:type="style:BundledImageDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@subNodeMappings[name='Operation']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@subNodeMappings[name='Operation']"/>
       </ownedElements>
+      <ownedElements xmi:type="diagram:DNodeListElement" uid="_TWeSgVtAEeuk8NiEvxa5og" name=" condition : BooleanExpression" tooltipText="">
+        <target xmi:type="ecore:EReference" href="tfsm.ecore#//EvaluateGuard/condition"/>
+        <semanticElements xmi:type="ecore:EReference" href="tfsm.ecore#//EvaluateGuard/condition"/>
+        <ownedStyle xmi:type="diagram:BundledImage" uid="_TWe5kFtAEeuk8NiEvxa5og" labelAlignment="LEFT" description="_TWeSgltAEeuk8NiEvxa5og" color="114,159,207">
+          <labelFormat>bold</labelFormat>
+        </ownedStyle>
+        <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@containerMappings[name='EC%20EClass']/@subNodeMappings[name='EC%20EReferenceNode']"/>
+      </ownedElements>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_197p4AH_EeqFPNc_0eQDcQ" name="[1..1] initialState" sourceNode="_19ioUAH_EeqFPNc_0eQDcQ" targetNode="_19kdgAH_EeqFPNc_0eQDcQ">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_197p4AH_EeqFPNc_0eQDcQ" name="[1..1] initialState" sourceNode="_19ioUAH_EeqFPNc_0eQDcQ" targetNode="_19kdgAH_EeqFPNc_0eQDcQ">
       <target xmi:type="ecore:EReference" href="tfsm.ecore#//TFSM/initialState"/>
       <semanticElements xmi:type="ecore:EReference" href="tfsm.ecore#//TFSM/initialState"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_198Q8wH_EeqFPNc_0eQDcQ" description="_198Q8AH_EeqFPNc_0eQDcQ" routingStyle="manhattan" strokeColor="0,0,0">
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_198Q9AH_EeqFPNc_0eQDcQ" showIcon="false">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_198Q8wH_EeqFPNc_0eQDcQ" description="_198Q8AH_EeqFPNc_0eQDcQ" routingStyle="manhattan" strokeColor="0,0,0">
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_198Q9AH_EeqFPNc_0eQDcQ" showIcon="false">
           <customFeatures>labelSize</customFeatures>
           <labelFormat>bold</labelFormat>
         </centerLabelStyle>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_198Q9QH_EeqFPNc_0eQDcQ" showIcon="false" labelColor="39,76,114">
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_198Q9QH_EeqFPNc_0eQDcQ" showIcon="false" labelColor="39,76,114">
           <customFeatures>labelSize</customFeatures>
         </endLabelStyle>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC_EReference']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_198Q9gH_EeqFPNc_0eQDcQ" name="[0..*] localEvents" sourceNode="_19ioUAH_EeqFPNc_0eQDcQ" targetNode="_19qkIQH_EeqFPNc_0eQDcQ">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_198Q9gH_EeqFPNc_0eQDcQ" name="[0..*] localEvents" sourceNode="_19ioUAH_EeqFPNc_0eQDcQ" targetNode="_19qkIQH_EeqFPNc_0eQDcQ">
       <target xmi:type="ecore:EReference" href="tfsm.ecore#//TFSM/localEvents"/>
       <semanticElements xmi:type="ecore:EReference" href="tfsm.ecore#//TFSM/localEvents"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_1984AwH_EeqFPNc_0eQDcQ" description="_1984AAH_EeqFPNc_0eQDcQ" sourceArrow="FillDiamond" routingStyle="manhattan" strokeColor="0,0,0">
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_1984BAH_EeqFPNc_0eQDcQ" showIcon="false">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_1984AwH_EeqFPNc_0eQDcQ" description="_1984AAH_EeqFPNc_0eQDcQ" sourceArrow="FillDiamond" routingStyle="manhattan" strokeColor="0,0,0">
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_1984BAH_EeqFPNc_0eQDcQ" showIcon="false">
           <customFeatures>labelSize</customFeatures>
         </centerLabelStyle>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_1984BQH_EeqFPNc_0eQDcQ" showIcon="false" labelColor="39,76,114">
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_1984BQH_EeqFPNc_0eQDcQ" showIcon="false" labelColor="39,76,114">
           <customFeatures>labelSize</customFeatures>
         </endLabelStyle>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC_EReference']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_1984BgH_EeqFPNc_0eQDcQ" name="[1..1] localClock" sourceNode="_19ioUAH_EeqFPNc_0eQDcQ" targetNode="_19ryQAH_EeqFPNc_0eQDcQ">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_1984BgH_EeqFPNc_0eQDcQ" name="[1..1] localClock" sourceNode="_19ioUAH_EeqFPNc_0eQDcQ" targetNode="_19ryQAH_EeqFPNc_0eQDcQ">
       <target xmi:type="ecore:EReference" href="tfsm.ecore#//TFSM/localClock"/>
       <semanticElements xmi:type="ecore:EReference" href="tfsm.ecore#//TFSM/localClock"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_199fEwH_EeqFPNc_0eQDcQ" description="_199fEAH_EeqFPNc_0eQDcQ" sourceArrow="FillDiamond" routingStyle="manhattan" strokeColor="0,0,0">
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_199fFAH_EeqFPNc_0eQDcQ" showIcon="false">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_199fEwH_EeqFPNc_0eQDcQ" description="_199fEAH_EeqFPNc_0eQDcQ" sourceArrow="FillDiamond" routingStyle="manhattan" strokeColor="0,0,0">
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_199fFAH_EeqFPNc_0eQDcQ" showIcon="false">
           <customFeatures>labelSize</customFeatures>
           <labelFormat>bold</labelFormat>
         </centerLabelStyle>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_199fFQH_EeqFPNc_0eQDcQ" showIcon="false" labelColor="39,76,114">
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_199fFQH_EeqFPNc_0eQDcQ" showIcon="false" labelColor="39,76,114">
           <customFeatures>labelSize</customFeatures>
         </endLabelStyle>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC_EReference']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_199fFgH_EeqFPNc_0eQDcQ" name="[0..*] ownedTransitions" sourceNode="_19ioUAH_EeqFPNc_0eQDcQ" targetNode="_19lEkQH_EeqFPNc_0eQDcQ">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_199fFgH_EeqFPNc_0eQDcQ" name="[0..*] ownedTransitions" sourceNode="_19ioUAH_EeqFPNc_0eQDcQ" targetNode="_19lEkQH_EeqFPNc_0eQDcQ">
       <target xmi:type="ecore:EReference" href="tfsm.ecore#//TFSM/ownedTransitions"/>
       <semanticElements xmi:type="ecore:EReference" href="tfsm.ecore#//TFSM/ownedTransitions"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_19-GIAH_EeqFPNc_0eQDcQ" description="_1984AAH_EeqFPNc_0eQDcQ" sourceArrow="FillDiamond" routingStyle="manhattan" strokeColor="0,0,0">
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_19-GIQH_EeqFPNc_0eQDcQ" showIcon="false">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_19-GIAH_EeqFPNc_0eQDcQ" description="_1984AAH_EeqFPNc_0eQDcQ" sourceArrow="FillDiamond" routingStyle="manhattan" strokeColor="0,0,0">
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_19-GIQH_EeqFPNc_0eQDcQ" showIcon="false">
           <customFeatures>labelSize</customFeatures>
         </centerLabelStyle>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_19-GIgH_EeqFPNc_0eQDcQ" showIcon="false" labelColor="39,76,114">
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_19-GIgH_EeqFPNc_0eQDcQ" showIcon="false" labelColor="39,76,114">
           <customFeatures>labelSize</customFeatures>
         </endLabelStyle>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC_EReference']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_19-GIwH_EeqFPNc_0eQDcQ" name="[1..1] ownedGuard" sourceNode="_19lEkQH_EeqFPNc_0eQDcQ" targetNode="_19ng0AH_EeqFPNc_0eQDcQ">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_19-GIwH_EeqFPNc_0eQDcQ" name="[1..1] ownedGuard" sourceNode="_19lEkQH_EeqFPNc_0eQDcQ" targetNode="_19ng0AH_EeqFPNc_0eQDcQ">
       <target xmi:type="ecore:EReference" href="tfsm.ecore#//Transition/ownedGuard"/>
       <semanticElements xmi:type="ecore:EReference" href="tfsm.ecore#//Transition/ownedGuard"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_19-tMAH_EeqFPNc_0eQDcQ" description="_199fEAH_EeqFPNc_0eQDcQ" sourceArrow="FillDiamond" routingStyle="manhattan" strokeColor="0,0,0">
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_19-tMQH_EeqFPNc_0eQDcQ" showIcon="false">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_19-tMAH_EeqFPNc_0eQDcQ" description="_199fEAH_EeqFPNc_0eQDcQ" sourceArrow="FillDiamond" routingStyle="manhattan" strokeColor="0,0,0">
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_19-tMQH_EeqFPNc_0eQDcQ" showIcon="false">
           <customFeatures>labelSize</customFeatures>
           <labelFormat>bold</labelFormat>
         </centerLabelStyle>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_19-tMgH_EeqFPNc_0eQDcQ" showIcon="false" labelColor="39,76,114">
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_19-tMgH_EeqFPNc_0eQDcQ" showIcon="false" labelColor="39,76,114">
           <customFeatures>labelSize</customFeatures>
         </endLabelStyle>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC_EReference']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_19-tMwH_EeqFPNc_0eQDcQ" name="[0..*] generatedEvents" sourceNode="_19lEkQH_EeqFPNc_0eQDcQ" targetNode="_19qkIQH_EeqFPNc_0eQDcQ">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_19-tMwH_EeqFPNc_0eQDcQ" name="[0..*] generatedEvents" sourceNode="_19lEkQH_EeqFPNc_0eQDcQ" targetNode="_19qkIQH_EeqFPNc_0eQDcQ">
       <target xmi:type="ecore:EReference" href="tfsm.ecore#//Transition/generatedEvents"/>
       <semanticElements xmi:type="ecore:EReference" href="tfsm.ecore#//Transition/generatedEvents"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_19_UQAH_EeqFPNc_0eQDcQ" routingStyle="manhattan" strokeColor="0,0,0">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_19_UQAH_EeqFPNc_0eQDcQ" routingStyle="manhattan" strokeColor="0,0,0">
         <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC_EReference']/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_19_UQQH_EeqFPNc_0eQDcQ" showIcon="false">
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_19_UQQH_EeqFPNc_0eQDcQ" showIcon="false">
           <customFeatures>labelSize</customFeatures>
         </centerLabelStyle>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_19_UQgH_EeqFPNc_0eQDcQ" showIcon="false" labelColor="39,76,114">
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_19_UQgH_EeqFPNc_0eQDcQ" showIcon="false" labelColor="39,76,114">
           <customFeatures>labelSize</customFeatures>
         </endLabelStyle>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC_EReference']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_19_UQwH_EeqFPNc_0eQDcQ" name="[1..1] onClock" sourceNode="_19pWAAH_EeqFPNc_0eQDcQ" targetNode="_19ryQAH_EeqFPNc_0eQDcQ">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_19_UQwH_EeqFPNc_0eQDcQ" name="[1..1] onClock" sourceNode="_19pWAAH_EeqFPNc_0eQDcQ" targetNode="_19ryQAH_EeqFPNc_0eQDcQ">
       <target xmi:type="ecore:EReference" href="tfsm.ecore#//TemporalGuard/onClock"/>
       <semanticElements xmi:type="ecore:EReference" href="tfsm.ecore#//TemporalGuard/onClock"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_19_7UAH_EeqFPNc_0eQDcQ" description="_198Q8AH_EeqFPNc_0eQDcQ" routingStyle="manhattan" strokeColor="0,0,0">
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_19_7UQH_EeqFPNc_0eQDcQ" showIcon="false">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_19_7UAH_EeqFPNc_0eQDcQ" description="_198Q8AH_EeqFPNc_0eQDcQ" routingStyle="manhattan" strokeColor="0,0,0">
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_19_7UQH_EeqFPNc_0eQDcQ" showIcon="false">
           <customFeatures>labelSize</customFeatures>
           <labelFormat>bold</labelFormat>
         </centerLabelStyle>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_19_7UgH_EeqFPNc_0eQDcQ" showIcon="false" labelColor="39,76,114">
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_19_7UgH_EeqFPNc_0eQDcQ" showIcon="false" labelColor="39,76,114">
           <customFeatures>labelSize</customFeatures>
         </endLabelStyle>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC_EReference']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_19_7UwH_EeqFPNc_0eQDcQ" name="[1..1] triggeringEvent" sourceNode="_19p9EAH_EeqFPNc_0eQDcQ" targetNode="_19qkIQH_EeqFPNc_0eQDcQ">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_19_7UwH_EeqFPNc_0eQDcQ" name="[1..1] triggeringEvent" sourceNode="_19p9EAH_EeqFPNc_0eQDcQ" targetNode="_19qkIQH_EeqFPNc_0eQDcQ">
       <target xmi:type="ecore:EReference" href="tfsm.ecore#//EventGuard/triggeringEvent"/>
       <semanticElements xmi:type="ecore:EReference" href="tfsm.ecore#//EventGuard/triggeringEvent"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_1-AiYAH_EeqFPNc_0eQDcQ" description="_198Q8AH_EeqFPNc_0eQDcQ" routingStyle="manhattan" strokeColor="0,0,0">
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_1-AiYQH_EeqFPNc_0eQDcQ" showIcon="false">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_1-AiYAH_EeqFPNc_0eQDcQ" description="_198Q8AH_EeqFPNc_0eQDcQ" routingStyle="manhattan" strokeColor="0,0,0">
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_1-AiYQH_EeqFPNc_0eQDcQ" showIcon="false">
           <customFeatures>labelSize</customFeatures>
           <labelFormat>bold</labelFormat>
         </centerLabelStyle>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_1-AiYgH_EeqFPNc_0eQDcQ" showIcon="false" labelColor="39,76,114">
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_1-AiYgH_EeqFPNc_0eQDcQ" showIcon="false" labelColor="39,76,114">
           <customFeatures>labelSize</customFeatures>
         </endLabelStyle>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC_EReference']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_1-AiYwH_EeqFPNc_0eQDcQ" name="[0..*] sollicitingTransitions" sourceNode="_19qkIQH_EeqFPNc_0eQDcQ" targetNode="_19lEkQH_EeqFPNc_0eQDcQ">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_1-AiYwH_EeqFPNc_0eQDcQ" name="[0..*] sollicitingTransitions" sourceNode="_19qkIQH_EeqFPNc_0eQDcQ" targetNode="_19lEkQH_EeqFPNc_0eQDcQ">
       <target xmi:type="ecore:EReference" href="tfsm.ecore#//FSMEvent/sollicitingTransitions"/>
       <semanticElements xmi:type="ecore:EReference" href="tfsm.ecore#//FSMEvent/sollicitingTransitions"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_1-BJcAH_EeqFPNc_0eQDcQ" routingStyle="manhattan" strokeColor="0,0,0">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_1-BJcAH_EeqFPNc_0eQDcQ" routingStyle="manhattan" strokeColor="0,0,0">
         <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC_EReference']/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_1-BJcQH_EeqFPNc_0eQDcQ" showIcon="false">
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_1-BJcQH_EeqFPNc_0eQDcQ" showIcon="false">
           <customFeatures>labelSize</customFeatures>
         </centerLabelStyle>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_1-BJcgH_EeqFPNc_0eQDcQ" showIcon="false" labelColor="39,76,114">
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_1-BJcgH_EeqFPNc_0eQDcQ" showIcon="false" labelColor="39,76,114">
           <customFeatures>labelSize</customFeatures>
         </endLabelStyle>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC_EReference']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_1-BJcwH_EeqFPNc_0eQDcQ" name="[0..*] tfsms" sourceNode="_19tAYAH_EeqFPNc_0eQDcQ" targetNode="_19ioUAH_EeqFPNc_0eQDcQ">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_1-BJcwH_EeqFPNc_0eQDcQ" name="[0..*] tfsms" sourceNode="_19tAYAH_EeqFPNc_0eQDcQ" targetNode="_19ioUAH_EeqFPNc_0eQDcQ">
       <target xmi:type="ecore:EReference" href="tfsm.ecore#//TimedSystem/tfsms"/>
       <semanticElements xmi:type="ecore:EReference" href="tfsm.ecore#//TimedSystem/tfsms"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_1-BwgAH_EeqFPNc_0eQDcQ" description="_1984AAH_EeqFPNc_0eQDcQ" sourceArrow="FillDiamond" routingStyle="manhattan" strokeColor="0,0,0">
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_1-BwgQH_EeqFPNc_0eQDcQ" showIcon="false">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_1-BwgAH_EeqFPNc_0eQDcQ" description="_1984AAH_EeqFPNc_0eQDcQ" sourceArrow="FillDiamond" routingStyle="manhattan" strokeColor="0,0,0">
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_1-BwgQH_EeqFPNc_0eQDcQ" showIcon="false">
           <customFeatures>labelSize</customFeatures>
         </centerLabelStyle>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_1-BwggH_EeqFPNc_0eQDcQ" showIcon="false" labelColor="39,76,114">
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_1-BwggH_EeqFPNc_0eQDcQ" showIcon="false" labelColor="39,76,114">
           <customFeatures>labelSize</customFeatures>
         </endLabelStyle>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC_EReference']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_1-BwgwH_EeqFPNc_0eQDcQ" name="[0..*] globalClocks" sourceNode="_19tAYAH_EeqFPNc_0eQDcQ" targetNode="_19ryQAH_EeqFPNc_0eQDcQ">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_1-BwgwH_EeqFPNc_0eQDcQ" name="[0..*] globalClocks" sourceNode="_19tAYAH_EeqFPNc_0eQDcQ" targetNode="_19ryQAH_EeqFPNc_0eQDcQ">
       <target xmi:type="ecore:EReference" href="tfsm.ecore#//TimedSystem/globalClocks"/>
       <semanticElements xmi:type="ecore:EReference" href="tfsm.ecore#//TimedSystem/globalClocks"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_1-CXkAH_EeqFPNc_0eQDcQ" description="_1984AAH_EeqFPNc_0eQDcQ" sourceArrow="FillDiamond" routingStyle="manhattan" strokeColor="0,0,0">
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_1-CXkQH_EeqFPNc_0eQDcQ" showIcon="false">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_1-CXkAH_EeqFPNc_0eQDcQ" description="_1984AAH_EeqFPNc_0eQDcQ" sourceArrow="FillDiamond" routingStyle="manhattan" strokeColor="0,0,0">
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_1-CXkQH_EeqFPNc_0eQDcQ" showIcon="false">
           <customFeatures>labelSize</customFeatures>
         </centerLabelStyle>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_1-CXkgH_EeqFPNc_0eQDcQ" showIcon="false" labelColor="39,76,114">
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_1-CXkgH_EeqFPNc_0eQDcQ" showIcon="false" labelColor="39,76,114">
           <customFeatures>labelSize</customFeatures>
         </endLabelStyle>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC_EReference']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_1-CXkwH_EeqFPNc_0eQDcQ" name="[0..*] globalEvents" sourceNode="_19tAYAH_EeqFPNc_0eQDcQ" targetNode="_19qkIQH_EeqFPNc_0eQDcQ">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_1-CXkwH_EeqFPNc_0eQDcQ" name="[0..*] globalEvents" sourceNode="_19tAYAH_EeqFPNc_0eQDcQ" targetNode="_19qkIQH_EeqFPNc_0eQDcQ">
       <target xmi:type="ecore:EReference" href="tfsm.ecore#//TimedSystem/globalEvents"/>
       <semanticElements xmi:type="ecore:EReference" href="tfsm.ecore#//TimedSystem/globalEvents"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_1-C-oAH_EeqFPNc_0eQDcQ" description="_1984AAH_EeqFPNc_0eQDcQ" sourceArrow="FillDiamond" routingStyle="manhattan" strokeColor="0,0,0">
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_1-C-oQH_EeqFPNc_0eQDcQ" showIcon="false">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_1-C-oAH_EeqFPNc_0eQDcQ" description="_1984AAH_EeqFPNc_0eQDcQ" sourceArrow="FillDiamond" routingStyle="manhattan" strokeColor="0,0,0">
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_1-C-oQH_EeqFPNc_0eQDcQ" showIcon="false">
           <customFeatures>labelSize</customFeatures>
         </centerLabelStyle>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_1-C-ogH_EeqFPNc_0eQDcQ" showIcon="false" labelColor="39,76,114">
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_1-C-ogH_EeqFPNc_0eQDcQ" showIcon="false" labelColor="39,76,114">
           <customFeatures>labelSize</customFeatures>
         </endLabelStyle>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC_EReference']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_1-DlsAH_EeqFPNc_0eQDcQ" sourceNode="_19ioUAH_EeqFPNc_0eQDcQ" targetNode="_19mSsAH_EeqFPNc_0eQDcQ">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_1-DlsAH_EeqFPNc_0eQDcQ" sourceNode="_19ioUAH_EeqFPNc_0eQDcQ" targetNode="_19mSsAH_EeqFPNc_0eQDcQ">
       <target xmi:type="ecore:EClass" href="tfsm.ecore#//TFSM"/>
       <semanticElements xmi:type="ecore:EClass" href="tfsm.ecore#//TFSM"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_1-EMwAH_EeqFPNc_0eQDcQ" targetArrow="InputClosedArrow" routingStyle="tree">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_1-EMwAH_EeqFPNc_0eQDcQ" targetArrow="InputClosedArrow" routingStyle="tree">
         <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC%20ESupertypes']/@style"/>
-        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" xmi:id="_1-EMwQH_EeqFPNc_0eQDcQ" showIcon="false">
+        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" uid="_1-EMwQH_EeqFPNc_0eQDcQ" showIcon="false">
           <labelFormat>italic</labelFormat>
         </beginLabelStyle>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_1-EMwgH_EeqFPNc_0eQDcQ" showIcon="false"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_1-EMwgH_EeqFPNc_0eQDcQ" showIcon="false"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC%20ESupertypes']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_1-EMwwH_EeqFPNc_0eQDcQ" sourceNode="_19kdgAH_EeqFPNc_0eQDcQ" targetNode="_19mSsAH_EeqFPNc_0eQDcQ">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_1-EMwwH_EeqFPNc_0eQDcQ" sourceNode="_19kdgAH_EeqFPNc_0eQDcQ" targetNode="_19mSsAH_EeqFPNc_0eQDcQ">
       <target xmi:type="ecore:EClass" href="tfsm.ecore#//State"/>
       <semanticElements xmi:type="ecore:EClass" href="tfsm.ecore#//State"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_1-Ez0AH_EeqFPNc_0eQDcQ" targetArrow="InputClosedArrow" routingStyle="tree">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_1-Ez0AH_EeqFPNc_0eQDcQ" targetArrow="InputClosedArrow" routingStyle="tree">
         <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC%20ESupertypes']/@style"/>
-        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" xmi:id="_1-Ez0QH_EeqFPNc_0eQDcQ" showIcon="false">
+        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" uid="_1-Ez0QH_EeqFPNc_0eQDcQ" showIcon="false">
           <labelFormat>italic</labelFormat>
         </beginLabelStyle>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_1-Ez0gH_EeqFPNc_0eQDcQ" showIcon="false"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_1-Ez0gH_EeqFPNc_0eQDcQ" showIcon="false"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC%20ESupertypes']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_1-Ez0wH_EeqFPNc_0eQDcQ" sourceNode="_19lEkQH_EeqFPNc_0eQDcQ" targetNode="_19mSsAH_EeqFPNc_0eQDcQ">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_1-Ez0wH_EeqFPNc_0eQDcQ" sourceNode="_19lEkQH_EeqFPNc_0eQDcQ" targetNode="_19mSsAH_EeqFPNc_0eQDcQ">
       <target xmi:type="ecore:EClass" href="tfsm.ecore#//Transition"/>
       <semanticElements xmi:type="ecore:EClass" href="tfsm.ecore#//Transition"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_1-Ez1AH_EeqFPNc_0eQDcQ" targetArrow="InputClosedArrow" routingStyle="tree">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_1-Ez1AH_EeqFPNc_0eQDcQ" targetArrow="InputClosedArrow" routingStyle="tree">
         <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC%20ESupertypes']/@style"/>
-        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" xmi:id="_1-Ez1QH_EeqFPNc_0eQDcQ" showIcon="false">
+        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" uid="_1-Ez1QH_EeqFPNc_0eQDcQ" showIcon="false">
           <labelFormat>italic</labelFormat>
         </beginLabelStyle>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_1-Ez1gH_EeqFPNc_0eQDcQ" showIcon="false"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_1-Ez1gH_EeqFPNc_0eQDcQ" showIcon="false"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC%20ESupertypes']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_1-Fa4AH_EeqFPNc_0eQDcQ" sourceNode="_19ng0AH_EeqFPNc_0eQDcQ" targetNode="_19mSsAH_EeqFPNc_0eQDcQ">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_1-Fa4AH_EeqFPNc_0eQDcQ" sourceNode="_19ng0AH_EeqFPNc_0eQDcQ" targetNode="_19mSsAH_EeqFPNc_0eQDcQ">
       <target xmi:type="ecore:EClass" href="tfsm.ecore#//Guard"/>
       <semanticElements xmi:type="ecore:EClass" href="tfsm.ecore#//Guard"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_1-Fa4QH_EeqFPNc_0eQDcQ" targetArrow="InputClosedArrow" routingStyle="tree">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_1-Fa4QH_EeqFPNc_0eQDcQ" targetArrow="InputClosedArrow" routingStyle="tree">
         <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC%20ESupertypes']/@style"/>
-        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" xmi:id="_1-Fa4gH_EeqFPNc_0eQDcQ" showIcon="false">
+        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" uid="_1-Fa4gH_EeqFPNc_0eQDcQ" showIcon="false">
           <labelFormat>italic</labelFormat>
         </beginLabelStyle>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_1-Fa4wH_EeqFPNc_0eQDcQ" showIcon="false"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_1-Fa4wH_EeqFPNc_0eQDcQ" showIcon="false"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC%20ESupertypes']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_1-Fa5AH_EeqFPNc_0eQDcQ" sourceNode="_19pWAAH_EeqFPNc_0eQDcQ" targetNode="_19ng0AH_EeqFPNc_0eQDcQ">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_1-Fa5AH_EeqFPNc_0eQDcQ" sourceNode="_19pWAAH_EeqFPNc_0eQDcQ" targetNode="_19ng0AH_EeqFPNc_0eQDcQ">
       <target xmi:type="ecore:EClass" href="tfsm.ecore#//TemporalGuard"/>
       <semanticElements xmi:type="ecore:EClass" href="tfsm.ecore#//TemporalGuard"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_1-GB8AH_EeqFPNc_0eQDcQ" targetArrow="InputClosedArrow" routingStyle="tree">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_1-GB8AH_EeqFPNc_0eQDcQ" targetArrow="InputClosedArrow" routingStyle="tree">
         <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC%20ESupertypes']/@style"/>
-        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" xmi:id="_1-GB8QH_EeqFPNc_0eQDcQ" showIcon="false">
+        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" uid="_1-GB8QH_EeqFPNc_0eQDcQ" showIcon="false">
           <labelFormat>italic</labelFormat>
         </beginLabelStyle>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_1-GB8gH_EeqFPNc_0eQDcQ" showIcon="false"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_1-GB8gH_EeqFPNc_0eQDcQ" showIcon="false"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC%20ESupertypes']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_1-GB8wH_EeqFPNc_0eQDcQ" sourceNode="_19p9EAH_EeqFPNc_0eQDcQ" targetNode="_19ng0AH_EeqFPNc_0eQDcQ">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_1-GB8wH_EeqFPNc_0eQDcQ" sourceNode="_19p9EAH_EeqFPNc_0eQDcQ" targetNode="_19ng0AH_EeqFPNc_0eQDcQ">
       <target xmi:type="ecore:EClass" href="tfsm.ecore#//EventGuard"/>
       <semanticElements xmi:type="ecore:EClass" href="tfsm.ecore#//EventGuard"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_1-GB9AH_EeqFPNc_0eQDcQ" targetArrow="InputClosedArrow" routingStyle="tree">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_1-GB9AH_EeqFPNc_0eQDcQ" targetArrow="InputClosedArrow" routingStyle="tree">
         <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC%20ESupertypes']/@style"/>
-        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" xmi:id="_1-GB9QH_EeqFPNc_0eQDcQ" showIcon="false">
+        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" uid="_1-GB9QH_EeqFPNc_0eQDcQ" showIcon="false">
           <labelFormat>italic</labelFormat>
         </beginLabelStyle>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_1-GB9gH_EeqFPNc_0eQDcQ" showIcon="false"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_1-GB9gH_EeqFPNc_0eQDcQ" showIcon="false"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC%20ESupertypes']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_1-GpAAH_EeqFPNc_0eQDcQ" sourceNode="_19qkIQH_EeqFPNc_0eQDcQ" targetNode="_19mSsAH_EeqFPNc_0eQDcQ">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_1-GpAAH_EeqFPNc_0eQDcQ" sourceNode="_19qkIQH_EeqFPNc_0eQDcQ" targetNode="_19mSsAH_EeqFPNc_0eQDcQ">
       <target xmi:type="ecore:EClass" href="tfsm.ecore#//FSMEvent"/>
       <semanticElements xmi:type="ecore:EClass" href="tfsm.ecore#//FSMEvent"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_1-GpAQH_EeqFPNc_0eQDcQ" targetArrow="InputClosedArrow" routingStyle="tree">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_1-GpAQH_EeqFPNc_0eQDcQ" targetArrow="InputClosedArrow" routingStyle="tree">
         <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC%20ESupertypes']/@style"/>
-        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" xmi:id="_1-GpAgH_EeqFPNc_0eQDcQ" showIcon="false">
+        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" uid="_1-GpAgH_EeqFPNc_0eQDcQ" showIcon="false">
           <labelFormat>italic</labelFormat>
         </beginLabelStyle>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_1-GpAwH_EeqFPNc_0eQDcQ" showIcon="false"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_1-GpAwH_EeqFPNc_0eQDcQ" showIcon="false"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC%20ESupertypes']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_1-GpBAH_EeqFPNc_0eQDcQ" sourceNode="_19ryQAH_EeqFPNc_0eQDcQ" targetNode="_19mSsAH_EeqFPNc_0eQDcQ">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_1-GpBAH_EeqFPNc_0eQDcQ" sourceNode="_19ryQAH_EeqFPNc_0eQDcQ" targetNode="_19mSsAH_EeqFPNc_0eQDcQ">
       <target xmi:type="ecore:EClass" href="tfsm.ecore#//FSMClock"/>
       <semanticElements xmi:type="ecore:EClass" href="tfsm.ecore#//FSMClock"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_1-HQEAH_EeqFPNc_0eQDcQ" targetArrow="InputClosedArrow" routingStyle="tree">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_1-HQEAH_EeqFPNc_0eQDcQ" targetArrow="InputClosedArrow" routingStyle="tree">
         <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC%20ESupertypes']/@style"/>
-        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" xmi:id="_1-HQEQH_EeqFPNc_0eQDcQ" showIcon="false">
+        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" uid="_1-HQEQH_EeqFPNc_0eQDcQ" showIcon="false">
           <labelFormat>italic</labelFormat>
         </beginLabelStyle>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_1-HQEgH_EeqFPNc_0eQDcQ" showIcon="false"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_1-HQEgH_EeqFPNc_0eQDcQ" showIcon="false"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC%20ESupertypes']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_1-HQEwH_EeqFPNc_0eQDcQ" sourceNode="_19tAYAH_EeqFPNc_0eQDcQ" targetNode="_19mSsAH_EeqFPNc_0eQDcQ">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_1-HQEwH_EeqFPNc_0eQDcQ" sourceNode="_19tAYAH_EeqFPNc_0eQDcQ" targetNode="_19mSsAH_EeqFPNc_0eQDcQ">
       <target xmi:type="ecore:EClass" href="tfsm.ecore#//TimedSystem"/>
       <semanticElements xmi:type="ecore:EClass" href="tfsm.ecore#//TimedSystem"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_1-HQFAH_EeqFPNc_0eQDcQ" targetArrow="InputClosedArrow" routingStyle="tree">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_1-HQFAH_EeqFPNc_0eQDcQ" targetArrow="InputClosedArrow" routingStyle="tree">
         <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC%20ESupertypes']/@style"/>
-        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" xmi:id="_1-HQFQH_EeqFPNc_0eQDcQ" showIcon="false">
+        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" uid="_1-HQFQH_EeqFPNc_0eQDcQ" showIcon="false">
           <labelFormat>italic</labelFormat>
         </beginLabelStyle>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_1-HQFgH_EeqFPNc_0eQDcQ" showIcon="false"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_1-HQFgH_EeqFPNc_0eQDcQ" showIcon="false"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC%20ESupertypes']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_1-H3IAH_EeqFPNc_0eQDcQ" sourceNode="_19tncAH_EeqFPNc_0eQDcQ" targetNode="_19ng0AH_EeqFPNc_0eQDcQ">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_1-H3IAH_EeqFPNc_0eQDcQ" sourceNode="_19tncAH_EeqFPNc_0eQDcQ" targetNode="_19ng0AH_EeqFPNc_0eQDcQ">
       <target xmi:type="ecore:EClass" href="tfsm.ecore#//EvaluateGuard"/>
       <semanticElements xmi:type="ecore:EClass" href="tfsm.ecore#//EvaluateGuard"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_1-H3IQH_EeqFPNc_0eQDcQ" targetArrow="InputClosedArrow" routingStyle="tree">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_1-H3IQH_EeqFPNc_0eQDcQ" targetArrow="InputClosedArrow" routingStyle="tree">
         <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC%20ESupertypes']/@style"/>
-        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" xmi:id="_1-H3IgH_EeqFPNc_0eQDcQ" showIcon="false">
+        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" uid="_1-H3IgH_EeqFPNc_0eQDcQ" showIcon="false">
           <labelFormat>italic</labelFormat>
         </beginLabelStyle>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_1-H3IwH_EeqFPNc_0eQDcQ" showIcon="false"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_1-H3IwH_EeqFPNc_0eQDcQ" showIcon="false"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='EC%20ESupertypes']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_1-IeMAH_EeqFPNc_0eQDcQ" sourceNode="_19kdgAH_EeqFPNc_0eQDcQ" targetNode="_19lEkQH_EeqFPNc_0eQDcQ" beginLabel="[1..1] target" endLabel="[0..*] incomingTransitions">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_1-IeMAH_EeqFPNc_0eQDcQ" sourceNode="_19kdgAH_EeqFPNc_0eQDcQ" targetNode="_19lEkQH_EeqFPNc_0eQDcQ" beginLabel="[1..1] target" endLabel="[0..*] incomingTransitions">
       <target xmi:type="ecore:EReference" href="tfsm.ecore#//State/incomingTransitions"/>
       <semanticElements xmi:type="ecore:EReference" href="tfsm.ecore#//State/incomingTransitions"/>
       <semanticElements xmi:type="ecore:EReference" href="tfsm.ecore#//Transition/target"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_1-IeMQH_EeqFPNc_0eQDcQ" sourceArrow="InputArrow" routingStyle="manhattan" strokeColor="0,0,0">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_1-IeMQH_EeqFPNc_0eQDcQ" sourceArrow="InputArrow" routingStyle="manhattan" strokeColor="0,0,0">
         <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='Bi-directional%20EC_EReference%20']/@style"/>
-        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" xmi:id="_1-IeMgH_EeqFPNc_0eQDcQ" showIcon="false"/>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_1-IeMwH_EeqFPNc_0eQDcQ" showIcon="false"/>
+        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" uid="_1-IeMgH_EeqFPNc_0eQDcQ" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_1-IeMwH_EeqFPNc_0eQDcQ" showIcon="false"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='Bi-directional%20EC_EReference%20']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_1-JFQAH_EeqFPNc_0eQDcQ" sourceNode="_19ioUAH_EeqFPNc_0eQDcQ" targetNode="_19kdgAH_EeqFPNc_0eQDcQ" beginLabel="[1..1] owningFSM" endLabel="[0..*] ownedStates">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_1-JFQAH_EeqFPNc_0eQDcQ" sourceNode="_19ioUAH_EeqFPNc_0eQDcQ" targetNode="_19kdgAH_EeqFPNc_0eQDcQ" beginLabel="[1..1] owningFSM" endLabel="[0..*] ownedStates">
       <target xmi:type="ecore:EReference" href="tfsm.ecore#//TFSM/ownedStates"/>
       <semanticElements xmi:type="ecore:EReference" href="tfsm.ecore#//TFSM/ownedStates"/>
       <semanticElements xmi:type="ecore:EReference" href="tfsm.ecore#//State/owningFSM"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_1-JFRAH_EeqFPNc_0eQDcQ" description="_1-JFQQH_EeqFPNc_0eQDcQ" sourceArrow="FillDiamond" routingStyle="manhattan" strokeColor="0,0,0">
-        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" xmi:id="_1-JFRQH_EeqFPNc_0eQDcQ" showIcon="false"/>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_1-JFRgH_EeqFPNc_0eQDcQ" showIcon="false"/>
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_1-JFRAH_EeqFPNc_0eQDcQ" description="_1-JFQQH_EeqFPNc_0eQDcQ" sourceArrow="FillDiamond" routingStyle="manhattan" strokeColor="0,0,0">
+        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" uid="_1-JFRQH_EeqFPNc_0eQDcQ" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_1-JFRgH_EeqFPNc_0eQDcQ" showIcon="false"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='Bi-directional%20EC_EReference%20']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_1-JsUAH_EeqFPNc_0eQDcQ" sourceNode="_19kdgAH_EeqFPNc_0eQDcQ" targetNode="_19lEkQH_EeqFPNc_0eQDcQ" beginLabel="[1..1] source" endLabel="[0..*] outgoingTransitions">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_1-JsUAH_EeqFPNc_0eQDcQ" sourceNode="_19kdgAH_EeqFPNc_0eQDcQ" targetNode="_19lEkQH_EeqFPNc_0eQDcQ" beginLabel="[1..1] source" endLabel="[0..*] outgoingTransitions">
       <target xmi:type="ecore:EReference" href="tfsm.ecore#//State/outgoingTransitions"/>
       <semanticElements xmi:type="ecore:EReference" href="tfsm.ecore#//State/outgoingTransitions"/>
       <semanticElements xmi:type="ecore:EReference" href="tfsm.ecore#//Transition/source"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_1-KTYAH_EeqFPNc_0eQDcQ" sourceArrow="InputArrow" routingStyle="manhattan" strokeColor="0,0,0">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_1-KTYAH_EeqFPNc_0eQDcQ" sourceArrow="InputArrow" routingStyle="manhattan" strokeColor="0,0,0">
         <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='Bi-directional%20EC_EReference%20']/@style"/>
-        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" xmi:id="_1-KTYQH_EeqFPNc_0eQDcQ" showIcon="false"/>
-        <endLabelStyle xmi:type="diagram:EndLabelStyle" xmi:id="_1-KTYgH_EeqFPNc_0eQDcQ" showIcon="false"/>
+        <beginLabelStyle xmi:type="diagram:BeginLabelStyle" uid="_1-KTYQH_EeqFPNc_0eQDcQ" showIcon="false"/>
+        <endLabelStyle xmi:type="diagram:EndLabelStyle" uid="_1-KTYgH_EeqFPNc_0eQDcQ" showIcon="false"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer/@edgeMappings[name='Bi-directional%20EC_EReference%20']"/>
     </ownedDiagramElements>
     <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']"/>
-    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" xmi:id="_1nFQIgH_EeqFPNc_0eQDcQ"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_1nFQIgH_EeqFPNc_0eQDcQ"/>
     <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@defaultLayer"/>
     <activatedLayers xmi:type="description_1:AdditionalLayer" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@additionalLayers[name='Package']"/>
     <activatedLayers xmi:type="description_1:AdditionalLayer" href="platform:/plugin/org.eclipse.emf.ecoretools.design/description/ecore.odesign#//@ownedViewpoints[name='Design']/@ownedRepresentations[name='Entities']/@additionalLayers[name='Validation']"/>

--- a/examples/moccmlTFSM/modeling_workbench/org.eclipse.gemoc.example.moccml.tfsm.pingpong_example/pingpong concurrentTFSM.launch
+++ b/examples/moccmlTFSM/modeling_workbench/org.eclipse.gemoc.example.moccml.tfsm.pingpong_example/pingpong concurrentTFSM.launch
@@ -1,17 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.gemoc.execution.concurrent.ccsljavaengine.ui.launcher">
-<booleanAttribute key="Concurrent" value="false"/>
-<booleanAttribute key="Do Exhaustive Simulation" value="false"/>
-<intAttribute key="GEMOC_ANIMATE_DELAY" value="0"/>
-<stringAttribute key="GEMOC_LAUNCH_INITIALIZATION_ARGUMENTS" value=""/>
-<stringAttribute key="GEMOC_LAUNCH_INITIALIZATION_METHOD" value=""/>
-<stringAttribute key="GEMOC_LAUNCH_SELECTED_DECIDER" value="Step by step user decider"/>
-<stringAttribute key="GEMOC_LAUNCH_SELECTED_LANGUAGE" value="concurrentTFSM"/>
-<booleanAttribute key="General" value="false"/>
-<booleanAttribute key="Generic MultiDimensional Trace" value="false"/>
-<booleanAttribute key="MultiBranch Reflective Trace" value="true"/>
-<stringAttribute key="Resource" value="/org.eclipse.gemoc.example.moccml.tfsm.pingpong_example/pingpong.tfsm"/>
-<stringAttribute key="TIMEMODEL_PATH" value=""/>
-<booleanAttribute key="VCD visualization" value="false"/>
-<stringAttribute key="airdResource" value="/org.eclipse.gemoc.example.moccml.tfsm.pingpong_example/pingpong.aird"/>
+    <booleanAttribute key="Concurrent" value="false"/>
+    <booleanAttribute key="Do Exhaustive Simulation" value="false"/>
+    <intAttribute key="GEMOC_ANIMATE_DELAY" value="0"/>
+    <stringAttribute key="GEMOC_LAUNCH_INITIALIZATION_ARGUMENTS" value=""/>
+    <stringAttribute key="GEMOC_LAUNCH_INITIALIZATION_METHOD" value=""/>
+    <stringAttribute key="GEMOC_LAUNCH_SELECTED_DECIDER" value="Step by step user decider"/>
+    <stringAttribute key="GEMOC_LAUNCH_SELECTED_LANGUAGE" value="ConcurrentTFSM"/>
+    <booleanAttribute key="General" value="false"/>
+    <booleanAttribute key="Generic MultiDimensional Data Trace" value="false"/>
+    <booleanAttribute key="Generic MultiDimensional Trace" value="false"/>
+    <booleanAttribute key="MultiBranch Reflective Trace" value="true"/>
+    <stringAttribute key="Resource" value="/org.eclipse.gemoc.example.moccml.tfsm.pingpong_example/pingpong.tfsm"/>
+    <stringAttribute key="TIMEMODEL_PATH" value=""/>
+    <booleanAttribute key="VCD visualization" value="false"/>
+    <stringAttribute key="airdResource" value="/org.eclipse.gemoc.example.moccml.tfsm.pingpong_example/pingpong.aird"/>
+    <booleanAttribute key="fsm MultiDimensional Trace" value="false"/>
+    <booleanAttribute key="org.eclipse.gemoc.trace.gemoc.addon_booleanOption" value="false"/>
 </launchConfiguration>

--- a/examples/moccmlTFSM/modeling_workbench/org.eclipse.gemoc.example.moccml.tfsm.pingpong_example/pingpong.aird
+++ b/examples/moccmlTFSM/modeling_workbench/org.eclipse.gemoc.example.moccml.tfsm.pingpong_example/pingpong.aird
@@ -1,28 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:description="http://www.eclipse.org/sirius/description/1.1.0" xmlns:description_1="http://www.eclipse.org/sirius/diagram/description/1.1.0" xmlns:diagram="http://www.eclipse.org/sirius/diagram/1.1.0" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.2/notation" xmlns:org.eclipse.gemoc.example.moccml.tfsm="http://www.gemoc.org/example/moccml/tfsm" xmlns:style="http://www.eclipse.org/sirius/diagram/description/style/1.1.0" xmlns:viewpoint="http://www.eclipse.org/sirius/1.1.0" xsi:schemaLocation="http://www.eclipse.org/sirius/description/1.1.0 http://www.eclipse.org/sirius/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/style/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description/style">
-  <viewpoint:DAnalysis xmi:id="_ApBHUACyEeqiUOpqUYDaqw" selectedViews="_BFfA4ACyEeqiUOpqUYDaqw" version="13.0.0.201804031646">
+<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:description="http://www.eclipse.org/sirius/description/1.1.0" xmlns:description_1="http://www.eclipse.org/sirius/diagram/description/1.1.0" xmlns:diagram="http://www.eclipse.org/sirius/diagram/1.1.0" xmlns:notation="http://www.eclipse.org/gmf/runtime/1.0.3/notation" xmlns:org.eclipse.gemoc.example.moccml.tfsm="http://www.gemoc.org/example/moccml/tfsm" xmlns:style="http://www.eclipse.org/sirius/diagram/description/style/1.1.0" xmlns:viewpoint="http://www.eclipse.org/sirius/1.1.0" xsi:schemaLocation="http://www.eclipse.org/sirius/description/1.1.0 http://www.eclipse.org/sirius/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description http://www.eclipse.org/sirius/diagram/description/style/1.1.0 http://www.eclipse.org/sirius/diagram/1.1.0#//description/style">
+  <viewpoint:DAnalysis uid="_ApBHUACyEeqiUOpqUYDaqw" selectedViews="_BFfA4ACyEeqiUOpqUYDaqw" version="14.3.1.202003261200">
     <semanticResources>pingpong.tfsm</semanticResources>
-    <ownedViews xmi:type="viewpoint:DView" xmi:id="_BFfA4ACyEeqiUOpqUYDaqw">
+    <ownedViews xmi:type="viewpoint:DView" uid="_BFfA4ACyEeqiUOpqUYDaqw">
       <viewpoint xmi:type="description:Viewpoint" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']"/>
-      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" xmi:id="_BHJNwACyEeqiUOpqUYDaqw" name="PingPong" repPath="#_BFfn8ACyEeqiUOpqUYDaqw">
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_BHJNwACyEeqiUOpqUYDaqw" name="PingPong" repPath="#_BHImsACyEeqiUOpqUYDaqw" changeId="5b6b2731-2fbf-4ec7-a116-f20c8c6aa31a">
         <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TimedSystem']"/>
         <target xmi:type="org.eclipse.gemoc.example.moccml.tfsm:TimedSystem" href="pingpong.tfsm#/"/>
       </ownedRepresentationDescriptors>
-      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" xmi:id="_BH-7QACyEeqiUOpqUYDaqw" name="Ponger" repPath="#_BHdW0ACyEeqiUOpqUYDaqw">
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_BH-7QACyEeqiUOpqUYDaqw" name="Ponger" repPath="#_BH-UMACyEeqiUOpqUYDaqw" changeId="4231b3d1-d501-4bc8-bf40-3a8f79c099aa">
         <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']"/>
         <target xmi:type="org.eclipse.gemoc.example.moccml.tfsm:TFSM" href="pingpong.tfsm#//@tfsms.0"/>
       </ownedRepresentationDescriptors>
-      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" xmi:id="_BIU5lgCyEeqiUOpqUYDaqw" name="Pinger" repPath="#_BIHeIACyEeqiUOpqUYDaqw">
+      <ownedRepresentationDescriptors xmi:type="viewpoint:DRepresentationDescriptor" uid="_BIU5lgCyEeqiUOpqUYDaqw" name="Pinger" repPath="#_BIU5gACyEeqiUOpqUYDaqw" changeId="89791ddc-31c9-42ea-be72-9990df8964d3">
         <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']"/>
         <target xmi:type="org.eclipse.gemoc.example.moccml.tfsm:TFSM" href="pingpong.tfsm#//@tfsms.1"/>
       </ownedRepresentationDescriptors>
     </ownedViews>
   </viewpoint:DAnalysis>
-  <diagram:DSemanticDiagram xmi:id="_BHImsACyEeqiUOpqUYDaqw" name="PingPong" uid="_BFfn8ACyEeqiUOpqUYDaqw">
-    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" xmi:id="_BHImsQCyEeqiUOpqUYDaqw" source="DANNOTATION_CUSTOMIZATION_KEY">
-      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" xmi:id="_BHImsgCyEeqiUOpqUYDaqw"/>
+  <diagram:DSemanticDiagram uid="_BHImsACyEeqiUOpqUYDaqw">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_BHImsQCyEeqiUOpqUYDaqw" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_BHImsgCyEeqiUOpqUYDaqw"/>
     </ownedAnnotationEntries>
-    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" xmi:id="_BHJ00ACyEeqiUOpqUYDaqw" source="GMF_DIAGRAMS">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_BHJ00ACyEeqiUOpqUYDaqw" source="GMF_DIAGRAMS">
       <data xmi:type="notation:Diagram" xmi:id="_BHJ00QCyEeqiUOpqUYDaqw" type="Sirius" element="_BHImsACyEeqiUOpqUYDaqw" measurementUnit="Pixel">
         <children xmi:type="notation:Node" xmi:id="_BHJ00wCyEeqiUOpqUYDaqw" type="2002" element="_BHImtACyEeqiUOpqUYDaqw">
           <children xmi:type="notation:Node" xmi:id="_BHKb4ACyEeqiUOpqUYDaqw" type="5006"/>
@@ -259,203 +259,203 @@
         </edges>
       </data>
     </ownedAnnotationEntries>
-    <ownedDiagramElements xmi:type="diagram:DNodeContainer" xmi:id="_BHImtACyEeqiUOpqUYDaqw" name="PingPong">
+    <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_BHImtACyEeqiUOpqUYDaqw" name="PingPong">
       <target xmi:type="org.eclipse.gemoc.example.moccml.tfsm:TimedSystem" href="pingpong.tfsm#/"/>
       <semanticElements xmi:type="org.eclipse.gemoc.example.moccml.tfsm:TimedSystem" href="pingpong.tfsm#/"/>
-      <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_BHImtQCyEeqiUOpqUYDaqw" showIcon="false" labelColor="39,76,114" borderSize="1" borderSizeComputationExpression="1" borderColor="252,233,79" foregroundColor="254,255,224">
+      <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_BHImtQCyEeqiUOpqUYDaqw" showIcon="false" labelColor="39,76,114" borderSize="1" borderSizeComputationExpression="1" borderColor="252,233,79" foregroundColor="254,255,224">
         <labelFormat>bold</labelFormat>
         <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TimedSystem']/@defaultLayer/@containerMappings[name='TimedSystem']/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TimedSystem']/@defaultLayer/@containerMappings[name='TimedSystem']"/>
-      <ownedDiagramElements xmi:type="diagram:DNodeContainer" xmi:id="_BHImtgCyEeqiUOpqUYDaqw" name="Ponger">
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_BHImtgCyEeqiUOpqUYDaqw" name="Ponger">
         <target xmi:type="org.eclipse.gemoc.example.moccml.tfsm:TFSM" href="pingpong.tfsm#//@tfsms.0"/>
         <semanticElements xmi:type="org.eclipse.gemoc.example.moccml.tfsm:TFSM" href="pingpong.tfsm#//@tfsms.0"/>
-        <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_BHImtwCyEeqiUOpqUYDaqw" showIcon="false" labelColor="77,137,20" borderSize="1" borderSizeComputationExpression="1" borderColor="138,226,52" foregroundColor="204,242,166">
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_BHImtwCyEeqiUOpqUYDaqw" showIcon="false" labelColor="77,137,20" borderSize="1" borderSizeComputationExpression="1" borderColor="138,226,52" foregroundColor="204,242,166">
           <labelFormat>bold</labelFormat>
           <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TimedSystem']/@defaultLayer/@containerMappings[name='TimedSystem']/@subContainerMappings[name='TFSM']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TimedSystem']/@defaultLayer/@containerMappings[name='TimedSystem']/@subContainerMappings[name='TFSM']"/>
-        <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_BHImuACyEeqiUOpqUYDaqw" name="initPonger" outgoingEdges="_07e_kAFpEeq4i6qZPrTy-Q" width="2" height="2" resizeKind="NSEW">
+        <ownedDiagramElements xmi:type="diagram:DNode" uid="_BHImuACyEeqiUOpqUYDaqw" name="initPonger" outgoingEdges="_07e_kAFpEeq4i6qZPrTy-Q" width="2" height="2" resizeKind="NSEW">
           <target xmi:type="org.eclipse.gemoc.example.moccml.tfsm:State" href="pingpong.tfsm#//@tfsms.0/@ownedStates.0"/>
           <semanticElements xmi:type="org.eclipse.gemoc.example.moccml.tfsm:State" href="pingpong.tfsm#//@tfsms.0/@ownedStates.0"/>
-          <ownedStyle xmi:type="diagram:Dot" xmi:id="_BHImuQCyEeqiUOpqUYDaqw" showIcon="false" labelColor="136,136,136" borderSize="3" borderSizeComputationExpression="3" backgroundColor="0,0,0">
+          <ownedStyle xmi:type="diagram:Dot" uid="_BHImuQCyEeqiUOpqUYDaqw" showIcon="false" labelColor="136,136,136" borderSize="3" borderSizeComputationExpression="3" backgroundColor="0,0,0">
             <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@nodeMappings[name='State']/@conditionnalStyles.0/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TimedSystem']/@defaultLayer/@containerMappings[name='TimedSystem']/@subContainerMappings[name='TFSM']/@subNodeMappings[name='States']"/>
         </ownedDiagramElements>
-        <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_BHImugCyEeqiUOpqUYDaqw" name="Pong_ofPonger" outgoingEdges="_07iC4AFpEeq4i6qZPrTy-Q" incomingEdges="_07e_kAFpEeq4i6qZPrTy-Q _07ip8gFpEeq4i6qZPrTy-Q" width="15" height="15" resizeKind="NSEW">
+        <ownedDiagramElements xmi:type="diagram:DNode" uid="_BHImugCyEeqiUOpqUYDaqw" name="Pong_ofPonger" outgoingEdges="_07iC4AFpEeq4i6qZPrTy-Q" incomingEdges="_07e_kAFpEeq4i6qZPrTy-Q _07ip8gFpEeq4i6qZPrTy-Q" width="15" height="15" resizeKind="NSEW">
           <target xmi:type="org.eclipse.gemoc.example.moccml.tfsm:State" href="pingpong.tfsm#//@tfsms.0/@ownedStates.1"/>
           <semanticElements xmi:type="org.eclipse.gemoc.example.moccml.tfsm:State" href="pingpong.tfsm#//@tfsms.0/@ownedStates.1"/>
           <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
           <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
           <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-          <ownedStyle xmi:type="diagram:Dot" xmi:id="_BHImuwCyEeqiUOpqUYDaqw" showIcon="false" labelColor="39,76,114" borderSize="3" borderSizeComputationExpression="3" borderColor="39,76,114" labelPosition="node" backgroundColor="255,255,255">
+          <ownedStyle xmi:type="diagram:Dot" uid="_BHImuwCyEeqiUOpqUYDaqw" showIcon="false" labelColor="39,76,114" borderSize="3" borderSizeComputationExpression="3" borderColor="39,76,114" labelPosition="node" backgroundColor="255,255,255">
             <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@nodeMappings[name='State']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TimedSystem']/@defaultLayer/@containerMappings[name='TimedSystem']/@subContainerMappings[name='TFSM']/@subNodeMappings[name='States']"/>
         </ownedDiagramElements>
-        <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_BHImvACyEeqiUOpqUYDaqw" name="Ping_ofPonger" outgoingEdges="_07ip8gFpEeq4i6qZPrTy-Q" incomingEdges="_07iC4AFpEeq4i6qZPrTy-Q" width="15" height="15" resizeKind="NSEW">
+        <ownedDiagramElements xmi:type="diagram:DNode" uid="_BHImvACyEeqiUOpqUYDaqw" name="Ping_ofPonger" outgoingEdges="_07ip8gFpEeq4i6qZPrTy-Q" incomingEdges="_07iC4AFpEeq4i6qZPrTy-Q" width="15" height="15" resizeKind="NSEW">
           <target xmi:type="org.eclipse.gemoc.example.moccml.tfsm:State" href="pingpong.tfsm#//@tfsms.0/@ownedStates.2"/>
           <semanticElements xmi:type="org.eclipse.gemoc.example.moccml.tfsm:State" href="pingpong.tfsm#//@tfsms.0/@ownedStates.2"/>
           <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
           <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
           <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-          <ownedStyle xmi:type="diagram:Dot" xmi:id="_BHImvQCyEeqiUOpqUYDaqw" showIcon="false" labelColor="39,76,114" borderSize="3" borderSizeComputationExpression="3" borderColor="39,76,114" labelPosition="node" backgroundColor="255,255,255">
+          <ownedStyle xmi:type="diagram:Dot" uid="_BHImvQCyEeqiUOpqUYDaqw" showIcon="false" labelColor="39,76,114" borderSize="3" borderSizeComputationExpression="3" borderColor="39,76,114" labelPosition="node" backgroundColor="255,255,255">
             <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@nodeMappings[name='State']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TimedSystem']/@defaultLayer/@containerMappings[name='TimedSystem']/@subContainerMappings[name='TFSM']/@subNodeMappings[name='States']"/>
         </ownedDiagramElements>
-        <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_BHImvgCyEeqiUOpqUYDaqw" name="pongerTime" width="5" height="5" resizeKind="NSEW">
+        <ownedDiagramElements xmi:type="diagram:DNode" uid="_BHImvgCyEeqiUOpqUYDaqw" name="pongerTime" width="5" height="5" resizeKind="NSEW">
           <target xmi:type="org.eclipse.gemoc.example.moccml.tfsm:FSMClock" href="pingpong.tfsm#//@tfsms.0/@localClock"/>
           <semanticElements xmi:type="org.eclipse.gemoc.example.moccml.tfsm:FSMClock" href="pingpong.tfsm#//@tfsms.0/@localClock"/>
-          <ownedStyle xmi:type="diagram:WorkspaceImage" xmi:id="_PQfRkACzEeqRW8GktD8qSg" showIcon="false" workspacePath="/org.eclipse.gemoc.example.moccml.tfsm.design/icons/clock_local_small.gif">
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_PQfRkACzEeqRW8GktD8qSg" showIcon="false" workspacePath="/org.eclipse.gemoc.example.moccml.tfsm.design/icons/clock_local_small.gif">
             <labelFormat>bold</labelFormat>
             <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@nodeMappings[name='Local%20Clock']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TimedSystem']/@defaultLayer/@containerMappings[name='TimedSystem']/@subContainerMappings[name='TFSM']/@subNodeMappings[name='Clocks']"/>
         </ownedDiagramElements>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNodeContainer" xmi:id="_BHImwACyEeqiUOpqUYDaqw" name="Pinger">
+      <ownedDiagramElements xmi:type="diagram:DNodeContainer" uid="_BHImwACyEeqiUOpqUYDaqw" name="Pinger">
         <target xmi:type="org.eclipse.gemoc.example.moccml.tfsm:TFSM" href="pingpong.tfsm#//@tfsms.1"/>
         <semanticElements xmi:type="org.eclipse.gemoc.example.moccml.tfsm:TFSM" href="pingpong.tfsm#//@tfsms.1"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:FlatContainerStyle" xmi:id="_BHImwQCyEeqiUOpqUYDaqw" showIcon="false" labelColor="77,137,20" borderSize="1" borderSizeComputationExpression="1" borderColor="138,226,52" foregroundColor="204,242,166">
+        <ownedStyle xmi:type="diagram:FlatContainerStyle" uid="_BHImwQCyEeqiUOpqUYDaqw" showIcon="false" labelColor="77,137,20" borderSize="1" borderSizeComputationExpression="1" borderColor="138,226,52" foregroundColor="204,242,166">
           <labelFormat>bold</labelFormat>
           <description xmi:type="style:FlatContainerStyleDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TimedSystem']/@defaultLayer/@containerMappings[name='TimedSystem']/@subContainerMappings[name='TFSM']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:ContainerMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TimedSystem']/@defaultLayer/@containerMappings[name='TimedSystem']/@subContainerMappings[name='TFSM']"/>
-        <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_BHImwgCyEeqiUOpqUYDaqw" name="initPinger" outgoingEdges="_07jRAgFpEeq4i6qZPrTy-Q" width="2" height="2" resizeKind="NSEW">
+        <ownedDiagramElements xmi:type="diagram:DNode" uid="_BHImwgCyEeqiUOpqUYDaqw" name="initPinger" outgoingEdges="_07jRAgFpEeq4i6qZPrTy-Q" width="2" height="2" resizeKind="NSEW">
           <target xmi:type="org.eclipse.gemoc.example.moccml.tfsm:State" href="pingpong.tfsm#//@tfsms.1/@ownedStates.0"/>
           <semanticElements xmi:type="org.eclipse.gemoc.example.moccml.tfsm:State" href="pingpong.tfsm#//@tfsms.1/@ownedStates.0"/>
-          <ownedStyle xmi:type="diagram:Dot" xmi:id="_BHImwwCyEeqiUOpqUYDaqw" showIcon="false" labelColor="136,136,136" borderSize="3" borderSizeComputationExpression="3" backgroundColor="0,0,0">
+          <ownedStyle xmi:type="diagram:Dot" uid="_BHImwwCyEeqiUOpqUYDaqw" showIcon="false" labelColor="136,136,136" borderSize="3" borderSizeComputationExpression="3" backgroundColor="0,0,0">
             <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@nodeMappings[name='State']/@conditionnalStyles.0/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TimedSystem']/@defaultLayer/@containerMappings[name='TimedSystem']/@subContainerMappings[name='TFSM']/@subNodeMappings[name='States']"/>
         </ownedDiagramElements>
-        <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_BHImxACyEeqiUOpqUYDaqw" name="Ping_ofPinger" outgoingEdges="_07kfIAFpEeq4i6qZPrTy-Q" incomingEdges="_07jRAgFpEeq4i6qZPrTy-Q _07ltQAFpEeq4i6qZPrTy-Q" width="15" height="15" resizeKind="NSEW">
+        <ownedDiagramElements xmi:type="diagram:DNode" uid="_BHImxACyEeqiUOpqUYDaqw" name="Ping_ofPinger" outgoingEdges="_07kfIAFpEeq4i6qZPrTy-Q" incomingEdges="_07jRAgFpEeq4i6qZPrTy-Q _07ltQAFpEeq4i6qZPrTy-Q" width="15" height="15" resizeKind="NSEW">
           <target xmi:type="org.eclipse.gemoc.example.moccml.tfsm:State" href="pingpong.tfsm#//@tfsms.1/@ownedStates.1"/>
           <semanticElements xmi:type="org.eclipse.gemoc.example.moccml.tfsm:State" href="pingpong.tfsm#//@tfsms.1/@ownedStates.1"/>
           <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
           <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
           <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-          <ownedStyle xmi:type="diagram:Dot" xmi:id="_BHImxQCyEeqiUOpqUYDaqw" showIcon="false" labelColor="39,76,114" borderSize="3" borderSizeComputationExpression="3" borderColor="39,76,114" labelPosition="node" backgroundColor="255,255,255">
+          <ownedStyle xmi:type="diagram:Dot" uid="_BHImxQCyEeqiUOpqUYDaqw" showIcon="false" labelColor="39,76,114" borderSize="3" borderSizeComputationExpression="3" borderColor="39,76,114" labelPosition="node" backgroundColor="255,255,255">
             <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@nodeMappings[name='State']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TimedSystem']/@defaultLayer/@containerMappings[name='TimedSystem']/@subContainerMappings[name='TFSM']/@subNodeMappings[name='States']"/>
         </ownedDiagramElements>
-        <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_BHImxgCyEeqiUOpqUYDaqw" name="Pong_ofPinger" outgoingEdges="_07ltQAFpEeq4i6qZPrTy-Q" incomingEdges="_07kfIAFpEeq4i6qZPrTy-Q" width="15" height="15" resizeKind="NSEW">
+        <ownedDiagramElements xmi:type="diagram:DNode" uid="_BHImxgCyEeqiUOpqUYDaqw" name="Pong_ofPinger" outgoingEdges="_07ltQAFpEeq4i6qZPrTy-Q" incomingEdges="_07kfIAFpEeq4i6qZPrTy-Q" width="15" height="15" resizeKind="NSEW">
           <target xmi:type="org.eclipse.gemoc.example.moccml.tfsm:State" href="pingpong.tfsm#//@tfsms.1/@ownedStates.2"/>
           <semanticElements xmi:type="org.eclipse.gemoc.example.moccml.tfsm:State" href="pingpong.tfsm#//@tfsms.1/@ownedStates.2"/>
           <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
           <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
           <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-          <ownedStyle xmi:type="diagram:Dot" xmi:id="_BHImxwCyEeqiUOpqUYDaqw" showIcon="false" labelColor="39,76,114" borderSize="3" borderSizeComputationExpression="3" borderColor="39,76,114" labelPosition="node" backgroundColor="255,255,255">
+          <ownedStyle xmi:type="diagram:Dot" uid="_BHImxwCyEeqiUOpqUYDaqw" showIcon="false" labelColor="39,76,114" borderSize="3" borderSizeComputationExpression="3" borderColor="39,76,114" labelPosition="node" backgroundColor="255,255,255">
             <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@nodeMappings[name='State']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TimedSystem']/@defaultLayer/@containerMappings[name='TimedSystem']/@subContainerMappings[name='TFSM']/@subNodeMappings[name='States']"/>
         </ownedDiagramElements>
-        <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_BHImyACyEeqiUOpqUYDaqw" name="pingerTime" width="5" height="5" resizeKind="NSEW">
+        <ownedDiagramElements xmi:type="diagram:DNode" uid="_BHImyACyEeqiUOpqUYDaqw" name="pingerTime" width="5" height="5" resizeKind="NSEW">
           <target xmi:type="org.eclipse.gemoc.example.moccml.tfsm:FSMClock" href="pingpong.tfsm#//@tfsms.1/@localClock"/>
           <semanticElements xmi:type="org.eclipse.gemoc.example.moccml.tfsm:FSMClock" href="pingpong.tfsm#//@tfsms.1/@localClock"/>
-          <ownedStyle xmi:type="diagram:WorkspaceImage" xmi:id="_PQl_QACzEeqRW8GktD8qSg" showIcon="false" workspacePath="/org.eclipse.gemoc.example.moccml.tfsm.design/icons/clock_local_small.gif">
+          <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_PQl_QACzEeqRW8GktD8qSg" showIcon="false" workspacePath="/org.eclipse.gemoc.example.moccml.tfsm.design/icons/clock_local_small.gif">
             <labelFormat>bold</labelFormat>
             <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@nodeMappings[name='Local%20Clock']/@style"/>
           </ownedStyle>
           <actualMapping xmi:type="description_1:NodeMappingImport" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TimedSystem']/@defaultLayer/@containerMappings[name='TimedSystem']/@subContainerMappings[name='TFSM']/@subNodeMappings[name='Clocks']"/>
         </ownedDiagramElements>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_BHImygCyEeqiUOpqUYDaqw" name="pong" width="-1" height="-1">
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_BHImygCyEeqiUOpqUYDaqw" name="pong" width="-1" height="-1">
         <target xmi:type="org.eclipse.gemoc.example.moccml.tfsm:FSMEvent" href="pingpong.tfsm#//@globalEvents.0"/>
         <semanticElements xmi:type="org.eclipse.gemoc.example.moccml.tfsm:FSMEvent" href="pingpong.tfsm#//@globalEvents.0"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:WorkspaceImage" xmi:id="_BHImywCyEeqiUOpqUYDaqw" showIcon="false" iconPath="event_small.png" borderSize="1" borderSizeComputationExpression="1" borderColor="156,12,12" workspacePath="/org.eclipse.gemoc.example.moccml.tfsm.design/icons/event_small.gif">
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_BHImywCyEeqiUOpqUYDaqw" showIcon="false" iconPath="event_small.png" borderSize="1" borderSizeComputationExpression="1" borderColor="156,12,12" workspacePath="/org.eclipse.gemoc.example.moccml.tfsm.design/icons/event_small.gif">
           <labelFormat>bold</labelFormat>
           <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TimedSystem']/@defaultLayer/@containerMappings[name='TimedSystem']/@subNodeMappings[name='Event']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TimedSystem']/@defaultLayer/@containerMappings[name='TimedSystem']/@subNodeMappings[name='Event']"/>
       </ownedDiagramElements>
-      <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_BHImzACyEeqiUOpqUYDaqw" name="ping" width="-1" height="-1">
+      <ownedDiagramElements xmi:type="diagram:DNode" uid="_BHImzACyEeqiUOpqUYDaqw" name="ping" width="-1" height="-1">
         <target xmi:type="org.eclipse.gemoc.example.moccml.tfsm:FSMEvent" href="pingpong.tfsm#//@globalEvents.1"/>
         <semanticElements xmi:type="org.eclipse.gemoc.example.moccml.tfsm:FSMEvent" href="pingpong.tfsm#//@globalEvents.1"/>
         <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
         <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
         <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-        <ownedStyle xmi:type="diagram:WorkspaceImage" xmi:id="_BHImzQCyEeqiUOpqUYDaqw" showIcon="false" iconPath="event_small.png" borderSize="1" borderSizeComputationExpression="1" borderColor="156,12,12" workspacePath="/org.eclipse.gemoc.example.moccml.tfsm.design/icons/event_small.gif">
+        <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_BHImzQCyEeqiUOpqUYDaqw" showIcon="false" iconPath="event_small.png" borderSize="1" borderSizeComputationExpression="1" borderColor="156,12,12" workspacePath="/org.eclipse.gemoc.example.moccml.tfsm.design/icons/event_small.gif">
           <labelFormat>bold</labelFormat>
           <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TimedSystem']/@defaultLayer/@containerMappings[name='TimedSystem']/@subNodeMappings[name='Event']/@style"/>
         </ownedStyle>
         <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TimedSystem']/@defaultLayer/@containerMappings[name='TimedSystem']/@subNodeMappings[name='Event']"/>
       </ownedDiagramElements>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_07e_kAFpEeq4i6qZPrTy-Q" name="after 0 on pongerTime&#xA; / &#xA;&#xA;" sourceNode="_BHImuACyEeqiUOpqUYDaqw" targetNode="_BHImugCyEeqiUOpqUYDaqw">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_07e_kAFpEeq4i6qZPrTy-Q" sourceNode="_BHImuACyEeqiUOpqUYDaqw" targetNode="_BHImugCyEeqiUOpqUYDaqw">
       <target xmi:type="org.eclipse.gemoc.example.moccml.tfsm:Transition" href="pingpong.tfsm#//@tfsms.0/@ownedTransitions.0"/>
       <semanticElements xmi:type="org.eclipse.gemoc.example.moccml.tfsm:Transition" href="pingpong.tfsm#//@tfsms.0/@ownedTransitions.0"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_07g0wAFpEeq4i6qZPrTy-Q" targetArrow="InputFillClosedArrow" size="2">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_07g0wAFpEeq4i6qZPrTy-Q" targetArrow="InputFillClosedArrow" size="2">
         <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@edgeMappings[name='EventTransition']/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_07g0wQFpEeq4i6qZPrTy-Q" showIcon="false"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_07g0wQFpEeq4i6qZPrTy-Q" showIcon="false"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMappingImport" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TimedSystem']/@defaultLayer/@edgeMappingImports[name='Transitions']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_07iC4AFpEeq4i6qZPrTy-Q" name="when ping&#xA; / &#xA;&#xA;" sourceNode="_BHImugCyEeqiUOpqUYDaqw" targetNode="_BHImvACyEeqiUOpqUYDaqw">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_07iC4AFpEeq4i6qZPrTy-Q" name="when ping" sourceNode="_BHImugCyEeqiUOpqUYDaqw" targetNode="_BHImvACyEeqiUOpqUYDaqw">
       <target xmi:type="org.eclipse.gemoc.example.moccml.tfsm:Transition" href="pingpong.tfsm#//@tfsms.0/@ownedTransitions.1"/>
       <semanticElements xmi:type="org.eclipse.gemoc.example.moccml.tfsm:Transition" href="pingpong.tfsm#//@tfsms.0/@ownedTransitions.1"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_07ip8AFpEeq4i6qZPrTy-Q" targetArrow="InputFillClosedArrow" size="2">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_07ip8AFpEeq4i6qZPrTy-Q" targetArrow="InputFillClosedArrow" size="2">
         <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@edgeMappings[name='EventTransition']/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_07ip8QFpEeq4i6qZPrTy-Q" showIcon="false"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_07ip8QFpEeq4i6qZPrTy-Q" showIcon="false"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMappingImport" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TimedSystem']/@defaultLayer/@edgeMappingImports[name='Transitions']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_07ip8gFpEeq4i6qZPrTy-Q" name="after 3 on pongerTime&#xA; / &#xA;&#xA;  !pong;" sourceNode="_BHImvACyEeqiUOpqUYDaqw" targetNode="_BHImugCyEeqiUOpqUYDaqw">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_07ip8gFpEeq4i6qZPrTy-Q" name="after 3 on pongerTime&#xA; / &#xA;  !pong;" sourceNode="_BHImvACyEeqiUOpqUYDaqw" targetNode="_BHImugCyEeqiUOpqUYDaqw">
       <target xmi:type="org.eclipse.gemoc.example.moccml.tfsm:Transition" href="pingpong.tfsm#//@tfsms.0/@ownedTransitions.2"/>
       <semanticElements xmi:type="org.eclipse.gemoc.example.moccml.tfsm:Transition" href="pingpong.tfsm#//@tfsms.0/@ownedTransitions.2"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_07jRAAFpEeq4i6qZPrTy-Q" targetArrow="InputFillClosedArrow" size="2">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_07jRAAFpEeq4i6qZPrTy-Q" targetArrow="InputFillClosedArrow" size="2">
         <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@edgeMappings[name='EventTransition']/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_07jRAQFpEeq4i6qZPrTy-Q" showIcon="false"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_07jRAQFpEeq4i6qZPrTy-Q" showIcon="false"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMappingImport" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TimedSystem']/@defaultLayer/@edgeMappingImports[name='Transitions']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_07jRAgFpEeq4i6qZPrTy-Q" name="after 0 on pingerTime&#xA; / &#xA;&#xA;" sourceNode="_BHImwgCyEeqiUOpqUYDaqw" targetNode="_BHImxACyEeqiUOpqUYDaqw">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_07jRAgFpEeq4i6qZPrTy-Q" sourceNode="_BHImwgCyEeqiUOpqUYDaqw" targetNode="_BHImxACyEeqiUOpqUYDaqw">
       <target xmi:type="org.eclipse.gemoc.example.moccml.tfsm:Transition" href="pingpong.tfsm#//@tfsms.1/@ownedTransitions.0"/>
       <semanticElements xmi:type="org.eclipse.gemoc.example.moccml.tfsm:Transition" href="pingpong.tfsm#//@tfsms.1/@ownedTransitions.0"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_07j4EAFpEeq4i6qZPrTy-Q" targetArrow="InputFillClosedArrow" size="2">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_07j4EAFpEeq4i6qZPrTy-Q" targetArrow="InputFillClosedArrow" size="2">
         <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@edgeMappings[name='EventTransition']/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_07j4EQFpEeq4i6qZPrTy-Q" showIcon="false"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_07j4EQFpEeq4i6qZPrTy-Q" showIcon="false"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMappingImport" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TimedSystem']/@defaultLayer/@edgeMappingImports[name='Transitions']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_07kfIAFpEeq4i6qZPrTy-Q" name="after 3 on pingerTime&#xA; / &#xA;&#xA;  !ping;" sourceNode="_BHImxACyEeqiUOpqUYDaqw" targetNode="_BHImxgCyEeqiUOpqUYDaqw">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_07kfIAFpEeq4i6qZPrTy-Q" name="after 3 on pingerTime&#xA; / &#xA;  !ping;" sourceNode="_BHImxACyEeqiUOpqUYDaqw" targetNode="_BHImxgCyEeqiUOpqUYDaqw">
       <target xmi:type="org.eclipse.gemoc.example.moccml.tfsm:Transition" href="pingpong.tfsm#//@tfsms.1/@ownedTransitions.1"/>
       <semanticElements xmi:type="org.eclipse.gemoc.example.moccml.tfsm:Transition" href="pingpong.tfsm#//@tfsms.1/@ownedTransitions.1"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_07lGMAFpEeq4i6qZPrTy-Q" targetArrow="InputFillClosedArrow" size="2">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_07lGMAFpEeq4i6qZPrTy-Q" targetArrow="InputFillClosedArrow" size="2">
         <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@edgeMappings[name='EventTransition']/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_07lGMQFpEeq4i6qZPrTy-Q" showIcon="false"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_07lGMQFpEeq4i6qZPrTy-Q" showIcon="false"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMappingImport" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TimedSystem']/@defaultLayer/@edgeMappingImports[name='Transitions']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_07ltQAFpEeq4i6qZPrTy-Q" name="when pong&#xA; / &#xA;&#xA;" sourceNode="_BHImxgCyEeqiUOpqUYDaqw" targetNode="_BHImxACyEeqiUOpqUYDaqw">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_07ltQAFpEeq4i6qZPrTy-Q" name="when pong" sourceNode="_BHImxgCyEeqiUOpqUYDaqw" targetNode="_BHImxACyEeqiUOpqUYDaqw">
       <target xmi:type="org.eclipse.gemoc.example.moccml.tfsm:Transition" href="pingpong.tfsm#//@tfsms.1/@ownedTransitions.2"/>
       <semanticElements xmi:type="org.eclipse.gemoc.example.moccml.tfsm:Transition" href="pingpong.tfsm#//@tfsms.1/@ownedTransitions.2"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_07ltQQFpEeq4i6qZPrTy-Q" targetArrow="InputFillClosedArrow" size="2">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_07ltQQFpEeq4i6qZPrTy-Q" targetArrow="InputFillClosedArrow" size="2">
         <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@edgeMappings[name='EventTransition']/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_07ltQgFpEeq4i6qZPrTy-Q" showIcon="false"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_07ltQgFpEeq4i6qZPrTy-Q" showIcon="false"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMappingImport" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TimedSystem']/@defaultLayer/@edgeMappingImports[name='Transitions']"/>
     </ownedDiagramElements>
     <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TimedSystem']"/>
-    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" xmi:id="_BHIm4ACyEeqiUOpqUYDaqw"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_BHIm4ACyEeqiUOpqUYDaqw"/>
     <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TimedSystem']/@defaultLayer"/>
     <activatedLayers xmi:type="description_1:AdditionalLayer" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TimedSystem']/@additionalLayers[name='Debug']"/>
     <target xmi:type="org.eclipse.gemoc.example.moccml.tfsm:TimedSystem" href="pingpong.tfsm#/"/>
   </diagram:DSemanticDiagram>
-  <diagram:DSemanticDiagram xmi:id="_BH-UMACyEeqiUOpqUYDaqw" name="Ponger" uid="_BHdW0ACyEeqiUOpqUYDaqw">
-    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" xmi:id="_BH-UMQCyEeqiUOpqUYDaqw" source="DANNOTATION_CUSTOMIZATION_KEY">
-      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" xmi:id="_BH-UMgCyEeqiUOpqUYDaqw"/>
+  <diagram:DSemanticDiagram uid="_BH-UMACyEeqiUOpqUYDaqw">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_BH-UMQCyEeqiUOpqUYDaqw" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_BH-UMgCyEeqiUOpqUYDaqw"/>
     </ownedAnnotationEntries>
-    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" xmi:id="_BIAJYACyEeqiUOpqUYDaqw" source="GMF_DIAGRAMS">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_BIAJYACyEeqiUOpqUYDaqw" source="GMF_DIAGRAMS">
       <data xmi:type="notation:Diagram" xmi:id="_BIAJYQCyEeqiUOpqUYDaqw" type="Sirius" element="_BH-UMACyEeqiUOpqUYDaqw" measurementUnit="Pixel">
         <children xmi:type="notation:Node" xmi:id="_BIAJYwCyEeqiUOpqUYDaqw" type="2001" element="_BH-UNACyEeqiUOpqUYDaqw">
           <children xmi:type="notation:Node" xmi:id="_BIAJZgCyEeqiUOpqUYDaqw" type="5002">
@@ -552,83 +552,83 @@
         </edges>
       </data>
     </ownedAnnotationEntries>
-    <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_BH-UNACyEeqiUOpqUYDaqw" name="pongerTime" width="5" height="5" resizeKind="NSEW">
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_BH-UNACyEeqiUOpqUYDaqw" name="pongerTime" width="5" height="5" resizeKind="NSEW">
       <target xmi:type="org.eclipse.gemoc.example.moccml.tfsm:FSMClock" href="pingpong.tfsm#//@tfsms.0/@localClock"/>
       <semanticElements xmi:type="org.eclipse.gemoc.example.moccml.tfsm:FSMClock" href="pingpong.tfsm#//@tfsms.0/@localClock"/>
-      <ownedStyle xmi:type="diagram:WorkspaceImage" xmi:id="_BH-UNQCyEeqiUOpqUYDaqw" showIcon="false" workspacePath="/org.eclipse.gemoc.example.moccml.tfsm.design/icons/clock_local_small.gif">
+      <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_BH-UNQCyEeqiUOpqUYDaqw" showIcon="false" workspacePath="/org.eclipse.gemoc.example.moccml.tfsm.design/icons/clock_local_small.gif">
         <labelFormat>bold</labelFormat>
         <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@nodeMappings[name='Local%20Clock']/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@nodeMappings[name='Local%20Clock']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_BH-UNgCyEeqiUOpqUYDaqw" name="initPonger" outgoingEdges="_BH-UPACyEeqiUOpqUYDaqw" width="2" height="2" resizeKind="NSEW">
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_BH-UNgCyEeqiUOpqUYDaqw" name="initPonger" outgoingEdges="_BH-UPACyEeqiUOpqUYDaqw" width="2" height="2" resizeKind="NSEW">
       <target xmi:type="org.eclipse.gemoc.example.moccml.tfsm:State" href="pingpong.tfsm#//@tfsms.0/@ownedStates.0"/>
       <semanticElements xmi:type="org.eclipse.gemoc.example.moccml.tfsm:State" href="pingpong.tfsm#//@tfsms.0/@ownedStates.0"/>
-      <ownedStyle xmi:type="diagram:Dot" xmi:id="_BH-UNwCyEeqiUOpqUYDaqw" showIcon="false" labelColor="136,136,136" borderSize="3" borderSizeComputationExpression="3" backgroundColor="0,0,0">
+      <ownedStyle xmi:type="diagram:Dot" uid="_BH-UNwCyEeqiUOpqUYDaqw" showIcon="false" labelColor="136,136,136" borderSize="3" borderSizeComputationExpression="3" backgroundColor="0,0,0">
         <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@nodeMappings[name='State']/@conditionnalStyles.0/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@nodeMappings[name='State']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_BH-UOACyEeqiUOpqUYDaqw" name="Pong_ofPonger" outgoingEdges="_BH-UPwCyEeqiUOpqUYDaqw" incomingEdges="_BH-UPACyEeqiUOpqUYDaqw _BH-UQgCyEeqiUOpqUYDaqw" width="15" height="15" resizeKind="NSEW">
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_BH-UOACyEeqiUOpqUYDaqw" name="Pong_ofPonger" outgoingEdges="_BH-UPwCyEeqiUOpqUYDaqw" incomingEdges="_BH-UPACyEeqiUOpqUYDaqw _BH-UQgCyEeqiUOpqUYDaqw" width="15" height="15" resizeKind="NSEW">
       <target xmi:type="org.eclipse.gemoc.example.moccml.tfsm:State" href="pingpong.tfsm#//@tfsms.0/@ownedStates.1"/>
       <semanticElements xmi:type="org.eclipse.gemoc.example.moccml.tfsm:State" href="pingpong.tfsm#//@tfsms.0/@ownedStates.1"/>
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
       <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
       <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-      <ownedStyle xmi:type="diagram:Dot" xmi:id="_BH-UOQCyEeqiUOpqUYDaqw" showIcon="false" labelColor="39,76,114" borderSize="3" borderSizeComputationExpression="3" borderColor="39,76,114" labelPosition="node" backgroundColor="255,255,255">
+      <ownedStyle xmi:type="diagram:Dot" uid="_BH-UOQCyEeqiUOpqUYDaqw" showIcon="false" labelColor="39,76,114" borderSize="3" borderSizeComputationExpression="3" borderColor="39,76,114" labelPosition="node" backgroundColor="255,255,255">
         <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@nodeMappings[name='State']/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@nodeMappings[name='State']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_BH-UOgCyEeqiUOpqUYDaqw" name="Ping_ofPonger" outgoingEdges="_BH-UQgCyEeqiUOpqUYDaqw" incomingEdges="_BH-UPwCyEeqiUOpqUYDaqw" width="15" height="15" resizeKind="NSEW">
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_BH-UOgCyEeqiUOpqUYDaqw" name="Ping_ofPonger" outgoingEdges="_BH-UQgCyEeqiUOpqUYDaqw" incomingEdges="_BH-UPwCyEeqiUOpqUYDaqw" width="15" height="15" resizeKind="NSEW">
       <target xmi:type="org.eclipse.gemoc.example.moccml.tfsm:State" href="pingpong.tfsm#//@tfsms.0/@ownedStates.2"/>
       <semanticElements xmi:type="org.eclipse.gemoc.example.moccml.tfsm:State" href="pingpong.tfsm#//@tfsms.0/@ownedStates.2"/>
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
       <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
       <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-      <ownedStyle xmi:type="diagram:Dot" xmi:id="_BH-UOwCyEeqiUOpqUYDaqw" showIcon="false" labelColor="39,76,114" borderSize="3" borderSizeComputationExpression="3" borderColor="39,76,114" labelPosition="node" backgroundColor="255,255,255">
+      <ownedStyle xmi:type="diagram:Dot" uid="_BH-UOwCyEeqiUOpqUYDaqw" showIcon="false" labelColor="39,76,114" borderSize="3" borderSizeComputationExpression="3" borderColor="39,76,114" labelPosition="node" backgroundColor="255,255,255">
         <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@nodeMappings[name='State']/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@nodeMappings[name='State']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_BH-UPACyEeqiUOpqUYDaqw" name="after 0 on pongerTime&#xA; / &#xA;&#xA;" sourceNode="_BH-UNgCyEeqiUOpqUYDaqw" targetNode="_BH-UOACyEeqiUOpqUYDaqw">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_BH-UPACyEeqiUOpqUYDaqw" sourceNode="_BH-UNgCyEeqiUOpqUYDaqw" targetNode="_BH-UOACyEeqiUOpqUYDaqw">
       <target xmi:type="org.eclipse.gemoc.example.moccml.tfsm:Transition" href="pingpong.tfsm#//@tfsms.0/@ownedTransitions.0"/>
       <semanticElements xmi:type="org.eclipse.gemoc.example.moccml.tfsm:Transition" href="pingpong.tfsm#//@tfsms.0/@ownedTransitions.0"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_BH-UPQCyEeqiUOpqUYDaqw" targetArrow="InputFillClosedArrow" size="2">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_BH-UPQCyEeqiUOpqUYDaqw" targetArrow="InputFillClosedArrow" size="2">
         <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@edgeMappings[name='EventTransition']/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_BH-UPgCyEeqiUOpqUYDaqw" showIcon="false"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_BH-UPgCyEeqiUOpqUYDaqw" showIcon="false"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@edgeMappings[name='EventTransition']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_BH-UPwCyEeqiUOpqUYDaqw" name="when ping&#xA; / &#xA;&#xA;" sourceNode="_BH-UOACyEeqiUOpqUYDaqw" targetNode="_BH-UOgCyEeqiUOpqUYDaqw">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_BH-UPwCyEeqiUOpqUYDaqw" name="when ping" sourceNode="_BH-UOACyEeqiUOpqUYDaqw" targetNode="_BH-UOgCyEeqiUOpqUYDaqw">
       <target xmi:type="org.eclipse.gemoc.example.moccml.tfsm:Transition" href="pingpong.tfsm#//@tfsms.0/@ownedTransitions.1"/>
       <semanticElements xmi:type="org.eclipse.gemoc.example.moccml.tfsm:Transition" href="pingpong.tfsm#//@tfsms.0/@ownedTransitions.1"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_BH-UQACyEeqiUOpqUYDaqw" targetArrow="InputFillClosedArrow" size="2">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_BH-UQACyEeqiUOpqUYDaqw" targetArrow="InputFillClosedArrow" size="2">
         <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@edgeMappings[name='EventTransition']/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_BH-UQQCyEeqiUOpqUYDaqw" showIcon="false"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_BH-UQQCyEeqiUOpqUYDaqw" showIcon="false"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@edgeMappings[name='EventTransition']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_BH-UQgCyEeqiUOpqUYDaqw" name="after 3 on pongerTime&#xA; / &#xA;&#xA;  !pong;" sourceNode="_BH-UOgCyEeqiUOpqUYDaqw" targetNode="_BH-UOACyEeqiUOpqUYDaqw">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_BH-UQgCyEeqiUOpqUYDaqw" name="after 3 on pongerTime&#xA; / &#xA;  !pong;" sourceNode="_BH-UOgCyEeqiUOpqUYDaqw" targetNode="_BH-UOACyEeqiUOpqUYDaqw">
       <target xmi:type="org.eclipse.gemoc.example.moccml.tfsm:Transition" href="pingpong.tfsm#//@tfsms.0/@ownedTransitions.2"/>
       <semanticElements xmi:type="org.eclipse.gemoc.example.moccml.tfsm:Transition" href="pingpong.tfsm#//@tfsms.0/@ownedTransitions.2"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_BH-UQwCyEeqiUOpqUYDaqw" targetArrow="InputFillClosedArrow" size="2">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_BH-UQwCyEeqiUOpqUYDaqw" targetArrow="InputFillClosedArrow" size="2">
         <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@edgeMappings[name='EventTransition']/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_BH-URACyEeqiUOpqUYDaqw" showIcon="false"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_BH-URACyEeqiUOpqUYDaqw" showIcon="false"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@edgeMappings[name='EventTransition']"/>
     </ownedDiagramElements>
     <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']"/>
-    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" xmi:id="_BH-URQCyEeqiUOpqUYDaqw"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_BH-URQCyEeqiUOpqUYDaqw"/>
     <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer"/>
     <activatedLayers xmi:type="description_1:AdditionalLayer" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@additionalLayers[name='Debug']"/>
     <target xmi:type="org.eclipse.gemoc.example.moccml.tfsm:TFSM" href="pingpong.tfsm#//@tfsms.0"/>
   </diagram:DSemanticDiagram>
-  <diagram:DSemanticDiagram xmi:id="_BIU5gACyEeqiUOpqUYDaqw" name="Pinger" uid="_BIHeIACyEeqiUOpqUYDaqw">
-    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" xmi:id="_BIU5gQCyEeqiUOpqUYDaqw" source="DANNOTATION_CUSTOMIZATION_KEY">
-      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" xmi:id="_BIU5ggCyEeqiUOpqUYDaqw"/>
+  <diagram:DSemanticDiagram uid="_BIU5gACyEeqiUOpqUYDaqw">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_BIU5gQCyEeqiUOpqUYDaqw" source="DANNOTATION_CUSTOMIZATION_KEY">
+      <data xmi:type="diagram:ComputedStyleDescriptionRegistry" uid="_BIU5ggCyEeqiUOpqUYDaqw"/>
     </ownedAnnotationEntries>
-    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" xmi:id="_BIVgkACyEeqiUOpqUYDaqw" source="GMF_DIAGRAMS">
+    <ownedAnnotationEntries xmi:type="description:AnnotationEntry" uid="_BIVgkACyEeqiUOpqUYDaqw" source="GMF_DIAGRAMS">
       <data xmi:type="notation:Diagram" xmi:id="_BIVgkQCyEeqiUOpqUYDaqw" type="Sirius" element="_BIU5gACyEeqiUOpqUYDaqw" measurementUnit="Pixel">
         <children xmi:type="notation:Node" xmi:id="_BIVgkwCyEeqiUOpqUYDaqw" type="2001" element="_BIU5hACyEeqiUOpqUYDaqw">
           <children xmi:type="notation:Node" xmi:id="_BIWHoACyEeqiUOpqUYDaqw" type="5002">
@@ -725,74 +725,74 @@
         </edges>
       </data>
     </ownedAnnotationEntries>
-    <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_BIU5hACyEeqiUOpqUYDaqw" name="pingerTime" width="5" height="5" resizeKind="NSEW">
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_BIU5hACyEeqiUOpqUYDaqw" name="pingerTime" width="5" height="5" resizeKind="NSEW">
       <target xmi:type="org.eclipse.gemoc.example.moccml.tfsm:FSMClock" href="pingpong.tfsm#//@tfsms.1/@localClock"/>
       <semanticElements xmi:type="org.eclipse.gemoc.example.moccml.tfsm:FSMClock" href="pingpong.tfsm#//@tfsms.1/@localClock"/>
-      <ownedStyle xmi:type="diagram:WorkspaceImage" xmi:id="_BIU5hQCyEeqiUOpqUYDaqw" showIcon="false" workspacePath="/org.eclipse.gemoc.example.moccml.tfsm.design/icons/clock_local_small.gif">
+      <ownedStyle xmi:type="diagram:WorkspaceImage" uid="_BIU5hQCyEeqiUOpqUYDaqw" showIcon="false" workspacePath="/org.eclipse.gemoc.example.moccml.tfsm.design/icons/clock_local_small.gif">
         <labelFormat>bold</labelFormat>
         <description xmi:type="style:WorkspaceImageDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@nodeMappings[name='Local%20Clock']/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@nodeMappings[name='Local%20Clock']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_BIU5hgCyEeqiUOpqUYDaqw" name="initPinger" outgoingEdges="_BIU5jACyEeqiUOpqUYDaqw" width="2" height="2" resizeKind="NSEW">
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_BIU5hgCyEeqiUOpqUYDaqw" name="initPinger" outgoingEdges="_BIU5jACyEeqiUOpqUYDaqw" width="2" height="2" resizeKind="NSEW">
       <target xmi:type="org.eclipse.gemoc.example.moccml.tfsm:State" href="pingpong.tfsm#//@tfsms.1/@ownedStates.0"/>
       <semanticElements xmi:type="org.eclipse.gemoc.example.moccml.tfsm:State" href="pingpong.tfsm#//@tfsms.1/@ownedStates.0"/>
-      <ownedStyle xmi:type="diagram:Dot" xmi:id="_BIU5hwCyEeqiUOpqUYDaqw" showIcon="false" labelColor="136,136,136" borderSize="3" borderSizeComputationExpression="3" backgroundColor="0,0,0">
+      <ownedStyle xmi:type="diagram:Dot" uid="_BIU5hwCyEeqiUOpqUYDaqw" showIcon="false" labelColor="136,136,136" borderSize="3" borderSizeComputationExpression="3" backgroundColor="0,0,0">
         <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@nodeMappings[name='State']/@conditionnalStyles.0/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@nodeMappings[name='State']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_BIU5iACyEeqiUOpqUYDaqw" name="Ping_ofPinger" outgoingEdges="_BIU5jwCyEeqiUOpqUYDaqw" incomingEdges="_BIU5jACyEeqiUOpqUYDaqw _BIU5kgCyEeqiUOpqUYDaqw" width="15" height="15" resizeKind="NSEW">
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_BIU5iACyEeqiUOpqUYDaqw" name="Ping_ofPinger" outgoingEdges="_BIU5jwCyEeqiUOpqUYDaqw" incomingEdges="_BIU5jACyEeqiUOpqUYDaqw _BIU5kgCyEeqiUOpqUYDaqw" width="15" height="15" resizeKind="NSEW">
       <target xmi:type="org.eclipse.gemoc.example.moccml.tfsm:State" href="pingpong.tfsm#//@tfsms.1/@ownedStates.1"/>
       <semanticElements xmi:type="org.eclipse.gemoc.example.moccml.tfsm:State" href="pingpong.tfsm#//@tfsms.1/@ownedStates.1"/>
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
       <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
       <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-      <ownedStyle xmi:type="diagram:Dot" xmi:id="_BIU5iQCyEeqiUOpqUYDaqw" showIcon="false" labelColor="39,76,114" borderSize="3" borderSizeComputationExpression="3" borderColor="39,76,114" labelPosition="node" backgroundColor="255,255,255">
+      <ownedStyle xmi:type="diagram:Dot" uid="_BIU5iQCyEeqiUOpqUYDaqw" showIcon="false" labelColor="39,76,114" borderSize="3" borderSizeComputationExpression="3" borderColor="39,76,114" labelPosition="node" backgroundColor="255,255,255">
         <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@nodeMappings[name='State']/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@nodeMappings[name='State']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DNode" xmi:id="_BIU5igCyEeqiUOpqUYDaqw" name="Pong_ofPinger" outgoingEdges="_BIU5kgCyEeqiUOpqUYDaqw" incomingEdges="_BIU5jwCyEeqiUOpqUYDaqw" width="15" height="15" resizeKind="NSEW">
+    <ownedDiagramElements xmi:type="diagram:DNode" uid="_BIU5igCyEeqiUOpqUYDaqw" name="Pong_ofPinger" outgoingEdges="_BIU5kgCyEeqiUOpqUYDaqw" incomingEdges="_BIU5jwCyEeqiUOpqUYDaqw" width="15" height="15" resizeKind="NSEW">
       <target xmi:type="org.eclipse.gemoc.example.moccml.tfsm:State" href="pingpong.tfsm#//@tfsms.1/@ownedStates.2"/>
       <semanticElements xmi:type="org.eclipse.gemoc.example.moccml.tfsm:State" href="pingpong.tfsm#//@tfsms.1/@ownedStates.2"/>
       <arrangeConstraints>KEEP_LOCATION</arrangeConstraints>
       <arrangeConstraints>KEEP_SIZE</arrangeConstraints>
       <arrangeConstraints>KEEP_RATIO</arrangeConstraints>
-      <ownedStyle xmi:type="diagram:Dot" xmi:id="_BIU5iwCyEeqiUOpqUYDaqw" showIcon="false" labelColor="39,76,114" borderSize="3" borderSizeComputationExpression="3" borderColor="39,76,114" labelPosition="node" backgroundColor="255,255,255">
+      <ownedStyle xmi:type="diagram:Dot" uid="_BIU5iwCyEeqiUOpqUYDaqw" showIcon="false" labelColor="39,76,114" borderSize="3" borderSizeComputationExpression="3" borderColor="39,76,114" labelPosition="node" backgroundColor="255,255,255">
         <description xmi:type="style:DotDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@nodeMappings[name='State']/@style"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:NodeMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@nodeMappings[name='State']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_BIU5jACyEeqiUOpqUYDaqw" name="after 0 on pingerTime&#xA; / &#xA;&#xA;" sourceNode="_BIU5hgCyEeqiUOpqUYDaqw" targetNode="_BIU5iACyEeqiUOpqUYDaqw">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_BIU5jACyEeqiUOpqUYDaqw" sourceNode="_BIU5hgCyEeqiUOpqUYDaqw" targetNode="_BIU5iACyEeqiUOpqUYDaqw">
       <target xmi:type="org.eclipse.gemoc.example.moccml.tfsm:Transition" href="pingpong.tfsm#//@tfsms.1/@ownedTransitions.0"/>
       <semanticElements xmi:type="org.eclipse.gemoc.example.moccml.tfsm:Transition" href="pingpong.tfsm#//@tfsms.1/@ownedTransitions.0"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_BIU5jQCyEeqiUOpqUYDaqw" targetArrow="InputFillClosedArrow" size="2">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_BIU5jQCyEeqiUOpqUYDaqw" targetArrow="InputFillClosedArrow" size="2">
         <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@edgeMappings[name='EventTransition']/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_BIU5jgCyEeqiUOpqUYDaqw" showIcon="false"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_BIU5jgCyEeqiUOpqUYDaqw" showIcon="false"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@edgeMappings[name='EventTransition']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_BIU5jwCyEeqiUOpqUYDaqw" name="after 3 on pingerTime&#xA; / &#xA;&#xA;  !ping;" sourceNode="_BIU5iACyEeqiUOpqUYDaqw" targetNode="_BIU5igCyEeqiUOpqUYDaqw">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_BIU5jwCyEeqiUOpqUYDaqw" name="after 3 on pingerTime&#xA; / &#xA;  !ping;" sourceNode="_BIU5iACyEeqiUOpqUYDaqw" targetNode="_BIU5igCyEeqiUOpqUYDaqw">
       <target xmi:type="org.eclipse.gemoc.example.moccml.tfsm:Transition" href="pingpong.tfsm#//@tfsms.1/@ownedTransitions.1"/>
       <semanticElements xmi:type="org.eclipse.gemoc.example.moccml.tfsm:Transition" href="pingpong.tfsm#//@tfsms.1/@ownedTransitions.1"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_BIU5kACyEeqiUOpqUYDaqw" targetArrow="InputFillClosedArrow" size="2">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_BIU5kACyEeqiUOpqUYDaqw" targetArrow="InputFillClosedArrow" size="2">
         <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@edgeMappings[name='EventTransition']/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_BIU5kQCyEeqiUOpqUYDaqw" showIcon="false"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_BIU5kQCyEeqiUOpqUYDaqw" showIcon="false"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@edgeMappings[name='EventTransition']"/>
     </ownedDiagramElements>
-    <ownedDiagramElements xmi:type="diagram:DEdge" xmi:id="_BIU5kgCyEeqiUOpqUYDaqw" name="when pong&#xA; / &#xA;&#xA;" sourceNode="_BIU5igCyEeqiUOpqUYDaqw" targetNode="_BIU5iACyEeqiUOpqUYDaqw">
+    <ownedDiagramElements xmi:type="diagram:DEdge" uid="_BIU5kgCyEeqiUOpqUYDaqw" name="when pong" sourceNode="_BIU5igCyEeqiUOpqUYDaqw" targetNode="_BIU5iACyEeqiUOpqUYDaqw">
       <target xmi:type="org.eclipse.gemoc.example.moccml.tfsm:Transition" href="pingpong.tfsm#//@tfsms.1/@ownedTransitions.2"/>
       <semanticElements xmi:type="org.eclipse.gemoc.example.moccml.tfsm:Transition" href="pingpong.tfsm#//@tfsms.1/@ownedTransitions.2"/>
-      <ownedStyle xmi:type="diagram:EdgeStyle" xmi:id="_BIU5kwCyEeqiUOpqUYDaqw" targetArrow="InputFillClosedArrow" size="2">
+      <ownedStyle xmi:type="diagram:EdgeStyle" uid="_BIU5kwCyEeqiUOpqUYDaqw" targetArrow="InputFillClosedArrow" size="2">
         <description xmi:type="style:EdgeStyleDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@edgeMappings[name='EventTransition']/@style"/>
-        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" xmi:id="_BIU5lACyEeqiUOpqUYDaqw" showIcon="false"/>
+        <centerLabelStyle xmi:type="diagram:CenterLabelStyle" uid="_BIU5lACyEeqiUOpqUYDaqw" showIcon="false"/>
       </ownedStyle>
       <actualMapping xmi:type="description_1:EdgeMapping" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer/@edgeMappings[name='EventTransition']"/>
     </ownedDiagramElements>
     <description xmi:type="description_1:DiagramDescription" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']"/>
-    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" xmi:id="_BIU5lQCyEeqiUOpqUYDaqw"/>
+    <filterVariableHistory xmi:type="diagram:FilterVariableHistory" uid="_BIU5lQCyEeqiUOpqUYDaqw"/>
     <activatedLayers xmi:type="description_1:Layer" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@defaultLayer"/>
     <activatedLayers xmi:type="description_1:AdditionalLayer" href="platform:/plugin/org.eclipse.gemoc.example.moccml.tfsm.design/description/TFSM.odesign#//@ownedViewpoints[name='TFSM_ViewPoint']/@ownedRepresentations[name='TFSM']/@additionalLayers[name='Debug']"/>
     <target xmi:type="org.eclipse.gemoc.example.moccml.tfsm:TFSM" href="pingpong.tfsm#//@tfsms.1"/>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 		<timesquare.p2.url>http://timesquare.inria.fr/update_site/2020</timesquare.p2.url>
 		<diverse-commons.p2.url>http://www.kermeta.org/diverse-commons/updates/latest</diverse-commons.p2.url>
 <!-- 		<sirius.p2.url>http://download.eclipse.org/sirius/updates/releases/6.1.3/photon</sirius.p2.url> -->
-		<efxclipse.p2.url>https://download.eclipse.org/efxclipse/updates-released/3.6.0/site</efxclipse.p2.url>
+		<efxclipse.p2.url>https://download.eclipse.org/efxclipse/updates-released/3.7.0/site</efxclipse.p2.url>
 	</properties>
     <modules>
     

--- a/pom.xml
+++ b/pom.xml
@@ -8,13 +8,13 @@
     <packaging>pom</packaging>    
     <properties>
 		<tycho-version>1.7.0</tycho-version>
-    	<xtend.version>2.21.0</xtend.version>
+    	<xtend.version>2.24.0</xtend.version>
 		<project.build.sourceEncoding>UTF8</project.build.sourceEncoding>
 		<tycho.scmUrl>scm:git:https://github.com/eclipse/gemoc-studio-execution-moccml.git</tycho.scmUrl>
 		
 		<maven.deploy.skip>true</maven.deploy.skip>
 		
-		<eclipse.release.p2.url>http://download.eclipse.org/releases/2020-03</eclipse.release.p2.url>
+		<eclipse.release.p2.url>http://download.eclipse.org/releases/2020-12</eclipse.release.p2.url>
 <!--     	<eclipse.photon.release.p2.url>http://download.eclipse.org/releases/photon</eclipse.photon.release.p2.url> -->
 		<k3.p2.url>http://www.kermeta.org/k3/update_2018-09-05</k3.p2.url>
 		<melange.p2.url>http://melange.inria.fr/updatesite/nightly/update_2020-06-19</melange.p2.url>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 		<eclipse.release.p2.url>http://download.eclipse.org/releases/2020-12</eclipse.release.p2.url>
 <!--     	<eclipse.photon.release.p2.url>http://download.eclipse.org/releases/photon</eclipse.photon.release.p2.url> -->
 		<k3.p2.url>http://www.kermeta.org/k3/update_2018-09-05</k3.p2.url>
-		<melange.p2.url>http://melange.inria.fr/updatesite/nightly/update_2020-06-19</melange.p2.url>
+		<melange.p2.url>http://melange.inria.fr/updatesite/nightly/update_2020-11-16</melange.p2.url>
 		<elk.p2.url>http://download.eclipse.org/elk/updates/releases/0.4.1</elk.p2.url>
 		<app4mc.p2.url>http://download.eclipse.org/app4mc/updatesites/releases/0.8.1</app4mc.p2.url>
 		<aspectJ.p2.url>http://download.eclipse.org/tools/ajdt/48/dev/update</aspectJ.p2.url>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <version>2.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>    
     <properties>
-		<tycho-version>1.7.0</tycho-version>
+		<tycho-version>2.2.0</tycho-version>
     	<xtend.version>2.24.0</xtend.version>
 		<project.build.sourceEncoding>UTF8</project.build.sourceEncoding>
 		<tycho.scmUrl>scm:git:https://github.com/eclipse/gemoc-studio-execution-moccml.git</tycho.scmUrl>


### PR DESCRIPTION
## Description

This bump the base Eclipse to Eclipse 2020-12

This allows to solve start issue on MacOS

## Changes

It also bump other components:

- Xtend/Xtext to 2.24.0
- Tycho to 2.2.0
 
## Contribution to issues

Contribute to #  
Closes # 

## Companion Pull Requests

<!-- optional, indicate if this PR must be accepted in conjunction with some PR in other GEMOC github repositories in order to provide a working Studio-->
<!-- you may have to edit this PR after submitting it in order to get all cross references between the PRs -->


 - PR https://github.com/eclipse/gemoc-studio/pull/219
 - PR https://github.com/eclipse/gemoc-studio-modeldebugging/pull/183
 - PR https://github.com/eclipse/gemoc-studio-execution-java/pull/14
 - PR https://github.com/eclipse/gemoc-studio-execution-ale/pull/46
 - PR https://github.com/eclipse/gemoc-studio-moccml/pull/17
