### PR TITLE
Add Sirius ELK support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 <!--     	<eclipse.photon.release.p2.url>http://download.eclipse.org/releases/photon</eclipse.photon.release.p2.url> -->
 		<k3.p2.url>http://www.kermeta.org/k3/update_2018-09-05</k3.p2.url>
 		<melange.p2.url>http://melange.inria.fr/updatesite/nightly/update_2020-11-16</melange.p2.url>
-		<elk.p2.url>http://download.eclipse.org/elk/updates/releases/0.4.1</elk.p2.url>
+		<elk.p2.url>http://download.eclipse.org/elk/updates/releases/0.7.1</elk.p2.url>
 		<app4mc.p2.url>http://download.eclipse.org/app4mc/updatesites/releases/0.8.1</app4mc.p2.url>
 		<aspectJ.p2.url>http://download.eclipse.org/tools/ajdt/48/dev/update</aspectJ.p2.url>
 		<!-- <timesquare.p2.url>http://www.i3s.unice.fr/~deantoni/photon/</timesquare.p2.url> -->

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 		<melange.p2.url>http://melange.inria.fr/updatesite/nightly/update_2020-11-16</melange.p2.url>
 		<elk.p2.url>http://download.eclipse.org/elk/updates/releases/0.7.1</elk.p2.url>
 		<app4mc.p2.url>http://download.eclipse.org/app4mc/updatesites/releases/0.8.1</app4mc.p2.url>
-		<aspectJ.p2.url>http://download.eclipse.org/tools/ajdt/48/dev/update</aspectJ.p2.url>
+		<aspectJ.p2.url>http://download.eclipse.org/tools/ajdt/410/dev/update</aspectJ.p2.url>
 		<!-- <timesquare.p2.url>http://www.i3s.unice.fr/~deantoni/photon/</timesquare.p2.url> -->
 		<timesquare.p2.url>http://timesquare.inria.fr/update_site/2020</timesquare.p2.url>
 		<diverse-commons.p2.url>http://www.kermeta.org/diverse-commons/updates/latest</diverse-commons.p2.url>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,6 @@
 		<k3.p2.url>http://www.kermeta.org/k3/update_2018-09-05</k3.p2.url>
 		<melange.p2.url>http://melange.inria.fr/updatesite/nightly/update_2020-11-16</melange.p2.url>
 		<elk.p2.url>http://download.eclipse.org/elk/updates/releases/0.7.1</elk.p2.url>
-		<app4mc.p2.url>http://download.eclipse.org/app4mc/updatesites/releases/0.8.1</app4mc.p2.url>
 		<aspectJ.p2.url>http://download.eclipse.org/tools/ajdt/410/dev/update</aspectJ.p2.url>
 		<!-- <timesquare.p2.url>http://www.i3s.unice.fr/~deantoni/photon/</timesquare.p2.url> -->
 		<timesquare.p2.url>http://timesquare.inria.fr/update_site/2020</timesquare.p2.url>

--- a/pom.xml
+++ b/pom.xml
@@ -77,11 +77,6 @@
             <layout>p2</layout>
             <url>${melange.p2.url}</url>
         </repository>
-        <repository>
-            <id>nebula</id>
-            <layout>p2</layout>
-            <url>http://archive.eclipse.org/nebula/Q22016/incubation</url>
-        </repository>
  <!--        <repository>
             <id>gemoc_non_concurrent</id>
             <layout>p2</layout>


### PR DESCRIPTION
## Description

This PR adds the ELK experimental support for Sirius. It provides better autolayout for Sirius diagram.

It also 
- cleans up some of the P2 repositories used while building
- remove some old repositories in the list of update sites presented in "Available update site" of the studio 

## Changes

ELK -> 0.7.1
Sirius ELK support
AJDT 4.10
remove nebula update site

 
## Contribution to issues

Closes https://github.com/eclipse/gemoc-studio/issues/221

## Companion Pull Requests

- https://github.com/eclipse/gemoc-studio/pull/222
- https://github.com/eclipse/gemoc-studio-modeldebugging/pull/184
- https://github.com/eclipse/gemoc-studio-execution-java/pull/15
- https://github.com/eclipse/gemoc-studio-moccml/pull/18

