### PR TITLE
Bump to Eclipse 2021-06

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,27 +5,21 @@
     <groupId>org.eclipse.gemoc.execution.concurrent.ccsljava</groupId>
     <artifactId>org.eclipse.gemoc.execution.concurrent.ccsljava.root</artifactId>
     <version>2.3.0-SNAPSHOT</version>
-    <packaging>pom</packaging>    
+    <packaging>pom</packaging>  
+    
+    <parent>
+		<groupId>org.eclipse.gemoc.gemoc-studio</groupId>
+		<artifactId>gemoc_studio-eclipse-bom</artifactId>
+		<version>3.3.0-SNAPSHOT</version>
+		<relativePath>../gemoc-studio/gemoc_studio/plugins/gemoc_studio-eclipse-bom</relativePath>
+	</parent>
+	  
     <properties>
-		<tycho-version>2.2.0</tycho-version>
-    	<xtend.version>2.24.0</xtend.version>
-		<project.build.sourceEncoding>UTF8</project.build.sourceEncoding>
 		<tycho.scmUrl>scm:git:https://github.com/eclipse/gemoc-studio-execution-moccml.git</tycho.scmUrl>
 		
-		<maven.deploy.skip>true</maven.deploy.skip>
-		
-		<eclipse.release.p2.url>http://download.eclipse.org/releases/2020-12</eclipse.release.p2.url>
-<!--     	<eclipse.photon.release.p2.url>http://download.eclipse.org/releases/photon</eclipse.photon.release.p2.url> -->
-		<k3.p2.url>http://www.kermeta.org/k3/update</k3.p2.url>
-		<melange.p2.url>http://melange.inria.fr/updatesite/nightly/update_2020-11-16</melange.p2.url>
-		<elk.p2.url>http://download.eclipse.org/elk/updates/releases/0.7.1</elk.p2.url>
-		<aspectJ.p2.url>http://download.eclipse.org/tools/ajdt/410/dev/update</aspectJ.p2.url>
-		<!-- <timesquare.p2.url>http://www.i3s.unice.fr/~deantoni/photon/</timesquare.p2.url> -->
-		<timesquare.p2.url>http://timesquare.inria.fr/update_site/2020</timesquare.p2.url>
-		<diverse-commons.p2.url>http://www.kermeta.org/diverse-commons/updates/latest</diverse-commons.p2.url>
-<!-- 		<sirius.p2.url>http://download.eclipse.org/sirius/updates/releases/6.1.3/photon</sirius.p2.url> -->
-		<efxclipse.p2.url>https://download.eclipse.org/efxclipse/updates-released/3.7.0/site</efxclipse.p2.url>
+		<maven.deploy.skip>true</maven.deploy.skip>	
 	</properties>
+	
     <modules>
     
         <!-- plugins -->


### PR DESCRIPTION
Bump Eclipse base to Eclipse 2021-06

Add a new root pom.xml acting as a BOM (Bill of Material) in order to centralize all update sites used by the gemoc studio repositories (this will help to bump most versions in a single file)

## Changes

 - increase  base version of the tools to the ones distributed with Eclipse 2021-06
 - add a new gemoc_studio-eclipse-bom project to centralize all update sites as properties in a single file
 - update splash screen using Eclipse IDE 2021-06 background
 
## Contribution to issues

Contribute to https://github.com/gemoc/gemoc-discussions/issues/6

## Companion Pull Requests

<!-- optional, indicate if this PR must be accepted in conjunction with some PR in other GEMOC github repositories in order to provide a working Studio-->
<!-- you may have to edit this PR after submitting it in order to get all cross references between the PRs -->

- https://github.com/eclipse/gemoc-studio/pull/231
- https://github.com/eclipse/gemoc-studio-modeldebugging/pull/196
- https://github.com/eclipse/gemoc-studio-execution-java/pull/19
- https://github.com/eclipse/gemoc-studio-execution-ale/pull/49
- https://github.com/eclipse/gemoc-studio-moccml/pull/19
- https://github.com/eclipse/gemoc-studio-execution-moccml/pull/54