### PR TITLE
Bump Studio to 3.4.0

### DIFF
--- a/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.extensions.k3.rtd.modelstate/META-INF/MANIFEST.MF
+++ b/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.extensions.k3.rtd.modelstate/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: GEMOC ccsljavaengine extension for K3 runtime data helper
 Bundle-SymbolicName: org.eclipse.gemoc.execution.concurrent.ccsljavaengine.extensions.k3.rtd.modelstate;singleton:=true
 Bundle-Version: 2.3.0.qualifier
 Bundle-ClassPath: .
-Bundle-Vendor: I3S/INRIA Kairos
+Bundle-Vendor: Eclipse GEMOC Project
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.gemoc.execution.concurrent.ccsljavaengine.extensions.k3.rtd.modelstate.k3ModelState,

--- a/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.extensions.k3/META-INF/MANIFEST.MF
+++ b/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.extensions.k3/META-INF/MANIFEST.MF
@@ -25,5 +25,5 @@ Export-Package: org.eclipse.gemoc.execution.concurrent.ccsljavaengine.extensions
  org.eclipse.gemoc.execution.concurrent.ccsljavaengine.extensions.k3.dsa.api,
  org.eclipse.gemoc.execution.concurrent.ccsljavaengine.extensions.k3.dsa.helper,
  org.eclipse.gemoc.execution.concurrent.ccsljavaengine.extensions.k3.dsa.impl
-Bundle-Vendor: Inria
+Bundle-Vendor: Eclipse GEMOC Project
 Automatic-Module-Name: org.eclipse.gemoc.execution.concurrent.ccsljavaengine.extensions.k3

--- a/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.extensions.timesquare/META-INF/MANIFEST.MF
+++ b/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.extensions.timesquare/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Gemoc extension for TimeSquare
+Bundle-Name: GEMOC extension for TimeSquare
 Bundle-SymbolicName: org.eclipse.gemoc.execution.concurrent.ccsljavaengine.extensions.timesquare
 Bundle-Version: 2.3.0.qualifier
 Bundle-Activator: org.eclipse.gemoc.execution.concurrent.ccsljavaengine.extensions.timesquare.Activator
@@ -37,4 +37,4 @@ Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.gemoc.execution.concurrent.ccsljavaengine.extensions.timesquare,
  org.eclipse.gemoc.execution.concurrent.ccsljavaengine.extensions.timesquare.moc.impl
-Bundle-Vendor: Inria Aoste/I3S
+Bundle-Vendor: Eclipse GEMOC Project

--- a/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.mse.model/META-INF/MANIFEST.MF
+++ b/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.mse.model/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.gemoc.execution.concurrent.ccsljavaengine.mse.model;singleton:=true
 Bundle-Version: 2.3.0.qualifier
 Bundle-ClassPath: .
-Bundle-Vendor: Inria
+Bundle-Vendor: Eclipse GEMOC Project
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.gemoc.execution.concurrent.ccsljavaengine.concurrentmse,

--- a/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.mse.model/plugin.properties
+++ b/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.mse.model/plugin.properties
@@ -11,5 +11,5 @@
 ###############################################################################
 #
 
-pluginName = GemocExecutionEngineTrace Model
-providerName = www.example.org
+pluginName = GEMOC ExecutionEngineTrace Model
+providerName = Eclipse GEMOC Project

--- a/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.stimuli_scenario.model/plugin.properties
+++ b/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.stimuli_scenario.model/plugin.properties
@@ -11,4 +11,4 @@
 #
 
 pluginName = StimuliScenario Model
-providerName = Inria
+providerName = Eclipse GEMOC Project

--- a/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.ui/META-INF/MANIFEST.MF
+++ b/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.ui/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Gemoc Concurrent Executable Modeling Workbench UI
 Bundle-SymbolicName: org.eclipse.gemoc.execution.concurrent.ccsljavaengine.ui;singleton:=true
 Bundle-Version: 2.3.0.qualifier
 Bundle-Activator: org.eclipse.gemoc.execution.concurrent.ccsljavaengine.ui.Activator
-Bundle-Vendor: Inria
+Bundle-Vendor: Eclipse GEMOC Project
 Require-Bundle: org.eclipse.ui.ide,
  org.eclipse.core.expressions;bundle-version="3.4.400",
  org.eclipse.debug.ui;bundle-version="3.8.2",

--- a/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine/META-INF/MANIFEST.MF
+++ b/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: CCSLJava Engine
+Bundle-Name: GEMOC CCSLJava Engine
 Bundle-SymbolicName: org.eclipse.gemoc.execution.concurrent.ccsljavaengine;singleton:=true
 Bundle-Version: 2.3.0.qualifier
 Bundle-Activator: org.eclipse.gemoc.execution.concurrent.ccsljavaengine.Activator
@@ -36,5 +36,5 @@ Export-Package: org.eclipse.gemoc.execution.concurrent.ccsljavaengine,
  org.eclipse.gemoc.execution.concurrent.ccsljavaengine.dse,
  org.eclipse.gemoc.execution.concurrent.ccsljavaengine.engine,
  org.eclipse.gemoc.execution.concurrent.ccsljavaengine.eventscheduling.trace
-Bundle-Vendor: Inria
+Bundle-Vendor: Eclipse GEMOC Project
 Automatic-Module-Name: org.eclipse.gemoc.execution.concurrent.ccsljavaengine

--- a/ccsljava_engine/tests/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.tests/META-INF/MANIFEST.MF
+++ b/ccsljava_engine/tests/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.tests/META-INF/MANIFEST.MF
@@ -16,4 +16,5 @@ Require-Bundle: com.google.guava,
  org.eclipse.gemoc.executionframework.engine;bundle-version="2.3.0",
  org.eclipse.core.runtime;bundle-version="3.12.0",
  org.junit;bundle-version="4.12.0"
+Bundle-Vendor: Eclipse GEMOC Project
 

--- a/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.api/META-INF/MANIFEST.MF
+++ b/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.api/META-INF/MANIFEST.MF
@@ -16,7 +16,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.transaction;bundle-version="1.9.1",
  org.eclipse.gemoc.commons.eclipse.pde;bundle-version="3.0.0"
 Bundle-ActivationPolicy: lazy
-Bundle-Vendor: Inria
+Bundle-Vendor: Eclipse GEMOC Project
 Automatic-Module-Name: org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.api
 Export-Package: org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.api.core,
  org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.api.dsa.executors,

--- a/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.ui/META-INF/MANIFEST.MF
+++ b/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.ui/META-INF/MANIFEST.MF
@@ -1,10 +1,10 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Gemoc Language Workbench UI
+Bundle-Name: GEMOC MoCCML Language Workbench UI
 Bundle-SymbolicName: org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.ui;singleton:=true
 Bundle-Version: 2.3.0.qualifier
 Bundle-Activator: org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.ui.Activator
-Bundle-Vendor: Inria
+Bundle-Vendor: Eclipse GEMOC Project
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.core.resources,

--- a/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.utils/META-INF/MANIFEST.MF
+++ b/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.utils/META-INF/MANIFEST.MF
@@ -19,4 +19,4 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.utils,
  org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.utils.ccsl
 Bundle-ClassPath: .
-Bundle-Vendor: Inria
+Bundle-Vendor: Eclipse GEMOC Project

--- a/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.moccml.example.deployer/META-INF/MANIFEST.MF
+++ b/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.moccml.example.deployer/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: GEMOC MOCCML Engine example deployer
+Bundle-Name: GEMOC MoCCML Engine example deployer
 Bundle-SymbolicName: org.eclipse.gemoc.execution.moccml.example.deployer;singleton:=true
 Bundle-Version: 2.3.0.qualifier
 Automatic-Module-Name: org.eclipse.gemoc.ale.language.sample.deployer
@@ -11,3 +11,4 @@ Require-Bundle: org.eclipse.gemoc.sequential.language.wb.sample.deployer,
  org.eclipse.core.runtime,
  org.eclipse.ui,
  org.eclipse.emf.common.ui
+Bundle-Vendor: Eclipse GEMOC Project

--- a/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.moccmlxdsml.metaprog/META-INF/MANIFEST.MF
+++ b/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.moccmlxdsml.metaprog/META-INF/MANIFEST.MF
@@ -16,3 +16,4 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.14.0",
  org.eclipse.ocl.xtext.completeocl,
  org.eclipse.ocl,
  org.eclipse.gemoc.xdsmlframework.extensions.kermeta3;bundle-version="4.0.0"
+Bundle-Vendor: Eclipse GEMOC Project

--- a/concurrent_addons/plugins/org.eclipse.gemoc.addon.eventscheduling.timeline/META-INF/MANIFEST.MF
+++ b/concurrent_addons/plugins/org.eclipse.gemoc.addon.eventscheduling.timeline/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Gemoc Event Scheduling Timeline Addon
+Bundle-Name: GEMOC Event Scheduling Timeline Addon
 Bundle-SymbolicName: org.eclipse.gemoc.addon.eventscheduling.timeline;singleton:=true
 Bundle-Version: 2.3.0.qualifier
 Bundle-Activator: org.eclipse.gemoc.addon.eventscheduling.timeline.Activator
@@ -27,6 +27,6 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.eclipse.gemoc.addon.eventscheduling.timeline,
  org.eclipse.gemoc.addon.eventscheduling.timeline.ui.commands,
  org.eclipse.gemoc.addon.eventscheduling.timeline.views.timeline
-Bundle-Vendor: Inria
+Bundle-Vendor: Eclipse GEMOC Project
 Automatic-Module-Name: org.eclipse.gemoc.addon.eventscheduling.timeline
 

--- a/concurrent_addons/plugins/org.eclipse.gemoc.addon.papyrusmodelanimator/META-INF/MANIFEST.MF
+++ b/concurrent_addons/plugins/org.eclipse.gemoc.addon.papyrusmodelanimator/META-INF/MANIFEST.MF
@@ -40,4 +40,4 @@ Require-Bundle: org.eclipse.draw2d,
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Export-Package: org.eclipse.gemoc.addon.papyrusmodelanimator
-Bundle-Vendor: Kairos INRIA/I3S
+Bundle-Vendor: Eclipse GEMOC Project

--- a/concurrent_addons/plugins/org.eclipse.gemoc.addon.vcdgenerator/META-INF/MANIFEST.MF
+++ b/concurrent_addons/plugins/org.eclipse.gemoc.addon.vcdgenerator/META-INF/MANIFEST.MF
@@ -27,4 +27,4 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Export-Package: org.eclipse.gemoc.addon.vcdgenerator,
  org.eclipse.gemoc.addon.vcdgenerator.behaviors,
  org.eclipse.gemoc.addon.vcdgenerator.manager
-Bundle-Vendor: Inria Aoste/I3S
+Bundle-Vendor: Eclipse GEMOC Project

--- a/examples/moccmlSigPML/language_workbench/org.eclipse.gemoc.example.moccmlsigpml.design/META-INF/MANIFEST.MF
+++ b/examples/moccmlSigPML/language_workbench/org.eclipse.gemoc.example.moccmlsigpml.design/META-INF/MANIFEST.MF
@@ -29,3 +29,4 @@ Export-Package:
  org.eclipse.gemoc.example.moccmlsigpml.design,
  org.eclipse.gemoc.example.moccmlsigpml.design.services
 Automatic-Module-Name: org.eclipse.gemoc.example.moccmlsigpml.design
+Bundle-Vendor: Eclipse GEMOC Project

--- a/examples/moccmlSigPML/language_workbench/org.eclipse.gemoc.example.moccmlsigpml.dse/META-INF/MANIFEST.MF
+++ b/examples/moccmlSigPML/language_workbench/org.eclipse.gemoc.example.moccmlsigpml.dse/META-INF/MANIFEST.MF
@@ -3,5 +3,5 @@ Bundle-ManifestVersion: 2
 Bundle-Name: SigPML MoC DSE
 Bundle-SymbolicName: org.eclipse.gemoc.example.moccmlsigpml.moc.dse;singleton:=true
 Bundle-Version: 2.3.0.qualifier
-Bundle-Vendor: INRIA/I3S Kairos
+Bundle-Vendor: Eclipse GEMOC Project
 Require-Bundle: org.eclipse.emf.ecore;bundle-version="2.10.1"

--- a/examples/moccmlSigPML/language_workbench/org.eclipse.gemoc.example.moccmlsigpml.groovy/META-INF/MANIFEST.MF
+++ b/examples/moccmlSigPML/language_workbench/org.eclipse.gemoc.example.moccmlsigpml.groovy/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Groovy
+Bundle-Name: moccmlsigpml Groovy
 Bundle-SymbolicName: org.eclipse.gemoc.example.moccmlsigpml.groovy
 Bundle-Version: 1.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
@@ -154,3 +154,4 @@ Export-Package: groovy.beans,
  org.codehaus.groovy.vmplugin.v6,
  org.codehaus.groovy.vmplugin.v7,
  org.codehaus.groovy.vmplugin.v8
+Bundle-Vendor: Eclipse GEMOC Project

--- a/examples/moccmlSigPML/language_workbench/org.eclipse.gemoc.example.moccmlsigpml.k3dsa/plugin.properties
+++ b/examples/moccmlSigPML/language_workbench/org.eclipse.gemoc.example.moccmlsigpml.k3dsa/plugin.properties
@@ -11,4 +11,4 @@
 #
 
 pluginName = org.eclipse.gemoc.example.moccmlsigpml.k3dsa
-providerName = www.gemoc.org
+providerName = Eclipse GEMOC Project

--- a/examples/moccmlSigPML/language_workbench/org.eclipse.gemoc.example.moccmlsigpml.lib/META-INF/MANIFEST.MF
+++ b/examples/moccmlSigPML/language_workbench/org.eclipse.gemoc.example.moccmlsigpml.lib/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: SigPML Moclib
 Bundle-SymbolicName: org.eclipse.gemoc.example.moccmlsigpml.moc.lib
 Bundle-Version: 2.3.0.qualifier
 Bundle-Activator: org.eclipse.gemoc.example.moccmlsigpml.moc.lib.Activator
-Bundle-Vendor: INRIA/I3S AOSTE
+Bundle-Vendor: Eclipse GEMOC Project
 Require-Bundle: org.eclipse.core.runtime
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy

--- a/examples/moccmlSigPML/language_workbench/org.eclipse.gemoc.example.moccmlsigpml.moc.dse/META-INF/MANIFEST.MF
+++ b/examples/moccmlSigPML/language_workbench/org.eclipse.gemoc.example.moccmlsigpml.moc.dse/META-INF/MANIFEST.MF
@@ -3,5 +3,5 @@ Bundle-ManifestVersion: 2
 Bundle-Name: SigPML MoC DSE
 Bundle-SymbolicName: org.eclipse.gemoc.example.moccmlsigpml.moc.dse;singleton:=true
 Bundle-Version: 2.3.0.qualifier
-Bundle-Vendor: INRIA/I3S Kairos
+Bundle-Vendor: Eclipse GEMOC Project
 Require-Bundle: org.eclipse.emf.ecore;bundle-version="2.10.1"

--- a/examples/moccmlSigPML/language_workbench/org.eclipse.gemoc.example.moccmlsigpml.moc.lib/META-INF/MANIFEST.MF
+++ b/examples/moccmlSigPML/language_workbench/org.eclipse.gemoc.example.moccmlsigpml.moc.lib/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: SigPML Moclib
 Bundle-SymbolicName: org.eclipse.gemoc.example.moccmlsigpml.moc.lib
 Bundle-Version: 2.3.0.qualifier
 Bundle-Activator: org.eclipse.gemoc.example.moccmlsigpml.moc.lib.Activator
-Bundle-Vendor: INRIA/I3S AOSTE
+Bundle-Vendor: Eclipse GEMOC Project
 Require-Bundle: org.eclipse.core.runtime
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy

--- a/examples/moccmlSigPML/language_workbench/org.eclipse.gemoc.example.moccmlsigpml.model.edit/plugin.properties
+++ b/examples/moccmlSigPML/language_workbench/org.eclipse.gemoc.example.moccmlsigpml.model.edit/plugin.properties
@@ -1,7 +1,7 @@
 #
 
 pluginName = SigPML Model Edit Support
-providerName = GEMOC
+providerName = Eclipse GEMOC Project
 
 _UI_CreateChild_text = {0}
 _UI_CreateChild_text2 = {1} {0}

--- a/examples/moccmlSigPML/language_workbench/org.eclipse.gemoc.example.moccmlsigpml.model.editor/plugin.properties
+++ b/examples/moccmlSigPML/language_workbench/org.eclipse.gemoc.example.moccmlsigpml.model.editor/plugin.properties
@@ -1,7 +1,7 @@
 #
 
 pluginName = SigPML Model Editor
-providerName = GEMOC
+providerName = Eclipse GEMOC Project
 
 _UI_SigpmlEditor_menu = &Sigpml Editor
 

--- a/examples/moccmlSigPML/language_workbench/org.eclipse.gemoc.example.moccmlsigpml.model.tests/plugin.properties
+++ b/examples/moccmlSigPML/language_workbench/org.eclipse.gemoc.example.moccmlsigpml.model.tests/plugin.properties
@@ -1,4 +1,4 @@
 #
 
 pluginName = SigPML Model Tests
-providerName = GEMOC
+providerName = Eclipse GEMOC Project

--- a/examples/moccmlSigPML/language_workbench/org.eclipse.gemoc.example.moccmlsigpml.model/plugin.properties
+++ b/examples/moccmlSigPML/language_workbench/org.eclipse.gemoc.example.moccmlsigpml.model/plugin.properties
@@ -11,4 +11,4 @@
 #
 
 pluginName = SigPML Model
-providerName = GEMOC
+providerName = Eclipse GEMOC Project

--- a/examples/moccmlSigPML/language_workbench/org.eclipse.gemoc.example.moccmlsigpml/META-INF/MANIFEST.MF
+++ b/examples/moccmlSigPML/language_workbench/org.eclipse.gemoc.example.moccmlsigpml/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.gemoc.example.moccmlsigpml
 Bundle-SymbolicName: org.eclipse.gemoc.example.moccmlsigpml;singleton:=true
 Export-Package: sigpml.xdsml.api.impl
 Bundle-Version: 2.3.0.qualifier
-Bundle-Name: Xdsml
+Bundle-Name: moccmlsigpml Xdsml
 Bundle-ClassPath: .
 Require-Bundle: org.eclipse.emf.ecore.xmi;bundle-version="2.8.0";visibility:="reexport",
  org.eclipse.gemoc.ultimateplotter;bundle-version="1.0.0";visibility:="reexport",
@@ -38,3 +38,4 @@ Bundle-ActivationPolicy: lazy
 Bundle-ManifestVersion: 2
 Bundle-Activator: org.eclipse.gemoc.example.moccmlsigpml.Activator
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-Vendor: Eclipse GEMOC Project

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.design/META-INF/MANIFEST.MF
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.design/META-INF/MANIFEST.MF
@@ -29,3 +29,4 @@ Bundle-ManifestVersion: 2
 Export-Package: org.eclipse.gemoc.example.moccml.tfsm.design,
  org.eclipse.gemoc.example.moccml.tfsm.design.services
 Automatic-Module-Name: org.eclipse.gemoc.example.moccml.tfsm.design
+Bundle-Vendor: Eclipse GEMOC Project

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.k3dsa/META-INF/MANIFEST.MF
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.k3dsa/META-INF/MANIFEST.MF
@@ -21,3 +21,4 @@ Bundle-ManifestVersion: 2
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Activator: org.eclipse.gemoc.example.moccml.tfsm.k3dsa.Activator
+Bundle-Vendor: Eclipse GEMOC Project

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.moc.dse/META-INF/MANIFEST.MF
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.moc.dse/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Dse
+Bundle-Name: moccml tfsm Dse
 Bundle-SymbolicName: org.eclipse.gemoc.example.moccml.tfsm.moc.dse
 Bundle-Version: 2.3.0.qualifier
 Bundle-Activator: org.eclipse.gemoc.example.moccml.tfsm.dse.Activator
@@ -9,3 +9,4 @@ Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.gemoc.example.moccml.tfsm.dse
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: org.eclipse.gemoc.example.moccml.tfsm.moc.dse
+Bundle-Vendor: Eclipse GEMOC Project

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.moc.lib/META-INF/MANIFEST.MF
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.moc.lib/META-INF/MANIFEST.MF
@@ -8,3 +8,4 @@ Require-Bundle: org.eclipse.core.runtime
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: org.eclipse.gemoc.example.moccml.tfsm.moc.lib
+Bundle-Vendor: Eclipse GEMOC Project

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.model.edit/plugin.properties
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.model.edit/plugin.properties
@@ -1,7 +1,7 @@
 #
 
 pluginName = Tfsm Model Edit Support
-providerName = www.example.org
+providerName = Eclipse GEMOC Project
 
 _UI_CreateChild_text = {0}
 _UI_CreateChild_text2 = {1} {0}

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.model.editor/plugin.properties
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.model.editor/plugin.properties
@@ -1,7 +1,7 @@
 #
 
 pluginName = Tfsm Model Editor
-providerName = www.example.org
+providerName = Eclipse GEMOC Project
 
 _UI_TfsmEditor_menu = &Tfsm Editor
 

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.model/plugin.properties
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.model/plugin.properties
@@ -11,4 +11,4 @@
 #
 
 pluginName = Tfsm Model
-providerName = www.example.org
+providerName = Eclipse GEMOC Project

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm/META-INF/MANIFEST.MF
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm/META-INF/MANIFEST.MF
@@ -30,3 +30,4 @@ Require-Bundle: org.eclipse.emf.ecore.xmi;bundle-version="2.8.0";visibility:="re
 Bundle-ActivationPolicy: lazy
 Bundle-ManifestVersion: 2
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-Vendor: Eclipse GEMOC Project

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <parent>
 		<groupId>org.eclipse.gemoc.gemoc-studio</groupId>
 		<artifactId>gemoc_studio-eclipse-bom</artifactId>
-		<version>3.3.0-SNAPSHOT</version>
+		<version>3.4.0-SNAPSHOT</version>
 		<relativePath>../gemoc-studio/gemoc_studio/plugins/gemoc_studio-eclipse-bom</relativePath>
 	</parent>
 	  

--- a/releng/org.eclipse.gemoc.concurrent_addons.feature/feature.properties
+++ b/releng/org.eclipse.gemoc.concurrent_addons.feature/feature.properties
@@ -17,7 +17,7 @@
 
 
 # "providerName" property - name of the company that provides the feature
-providerName=Eclipse Modeling Project
+providerName=Eclipse GEMOC Project
 
 # "licenseURL" property - URL of the "Feature License"
 # do not translate value - just change to point to a locale-specific HTML page

--- a/releng/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.feature/feature.properties
+++ b/releng/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.feature/feature.properties
@@ -17,7 +17,7 @@
 
 
 # "providerName" property - name of the company that provides the feature
-providerName=Eclipse Modeling Project
+providerName=Eclipse GEMOC Project
 
 # "licenseURL" property - URL of the "Feature License"
 # do not translate value - just change to point to a locale-specific HTML page

--- a/releng/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.ui.feature/feature.properties
+++ b/releng/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.ui.feature/feature.properties
@@ -17,7 +17,7 @@
 
 
 # "providerName" property - name of the company that provides the feature
-providerName=Eclipse Modeling Project
+providerName=Eclipse GEMOC Project
 
 # "licenseURL" property - URL of the "Feature License"
 # do not translate value - just change to point to a locale-specific HTML page

--- a/releng/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.feature/feature.properties
+++ b/releng/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.feature/feature.properties
@@ -17,7 +17,7 @@
 
 
 # "providerName" property - name of the company that provides the feature
-providerName=Eclipse Modeling Project
+providerName=Eclipse GEMOC Project
 
 # "licenseURL" property - URL of the "Feature License"
 # do not translate value - just change to point to a locale-specific HTML page

--- a/releng/org.eclipse.gemoc.execution.moccml.feature/feature.properties
+++ b/releng/org.eclipse.gemoc.execution.moccml.feature/feature.properties
@@ -17,7 +17,7 @@
 
 
 # "providerName" property - name of the company that provides the feature
-providerName=Eclipse Modeling Project
+providerName=Eclipse GEMOC Project
 
 # "licenseURL" property - URL of the "Feature License"
 # do not translate value - just change to point to a locale-specific HTML page

--- a/releng/org.eclipse.gemoc.execution.moccml.feature/feature.xml
+++ b/releng/org.eclipse.gemoc.execution.moccml.feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.gemoc.execution.moccml.feature"
       label="GEMOC ExecutionMOCCML"
-      version="2.3.0.qualifier"
+      version="3.4.0.qualifier"
       provider-name="%providerName"
       image="gemocstudio32.png">
 


### PR DESCRIPTION
## Description

Increase Studio version to 3.4.0.xxx

Update vendor name of all plugins and features to `Eclipse GEMOC Project`

## Contribution to issues

Contribute to https://github.com/eclipse/gemoc-studio/issues/235

## Companion Pull Requests

<!-- optional, indicate if this PR must be accepted in conjunction with some PR in other GEMOC github repositories in order to provide a working Studio-->
<!-- you may have to edit this PR after submitting it in order to get all cross references between the PRs -->

 - https://github.com/eclipse/gemoc-studio/pull/236
- https://github.com/eclipse/gemoc-studio-modeldebugging/pull/198
- https://github.com/eclipse/gemoc-studio-moccml/pull/20