### PR TITLE
Bump to 3.5.0

### DIFF
--- a/ccsljava_engine/plugins/pom.xml
+++ b/ccsljava_engine/plugins/pom.xml
@@ -12,7 +12,7 @@
 		<relativePath>../..</relativePath>
 		<groupId>org.eclipse.gemoc.gemoc-studio-execution-moccml.bundle</groupId>
 		<artifactId>org.eclipse.gemoc.execution.concurrent.ccsljava.root</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.gemoc.execution.concurrent.ccsljavaengine.plugins</artifactId>

--- a/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.moccml.example.deployer/META-INF/MANIFEST.MF
+++ b/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.moccml.example.deployer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: GEMOC MoCCML Engine example deployer
 Bundle-SymbolicName: org.eclipse.gemoc.execution.moccml.example.deployer;singleton:=true
-Bundle-Version: 3.4.0.qualifier
+Bundle-Version: 3.5.0.qualifier
 Automatic-Module-Name: org.eclipse.gemoc.ale.language.sample.deployer
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.gemoc.sequential.language.wb.sample.deployer,

--- a/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.moccml.example.deployer/pom.xml
+++ b/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.moccml.example.deployer/pom.xml
@@ -18,7 +18,7 @@
 		<relativePath>../../..</relativePath>
 		<groupId>org.eclipse.gemoc.gemoc-studio-execution-moccml.bundle</groupId>
 		<artifactId>org.eclipse.gemoc.execution.concurrent.ccsljava.root</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.gemoc.execution.moccml.example.deployer</artifactId>

--- a/ccsljava_xdsml/plugins/pom.xml
+++ b/ccsljava_xdsml/plugins/pom.xml
@@ -12,7 +12,7 @@
 		<relativePath>../..</relativePath>
 		<groupId>org.eclipse.gemoc.gemoc-studio-execution-moccml.bundle</groupId>
 		<artifactId>org.eclipse.gemoc.execution.concurrent.ccsljava.root</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.plugins</artifactId>

--- a/ccsljava_xdsml/tests/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.tests/pom.xml
+++ b/ccsljava_xdsml/tests/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.tests/pom.xml
@@ -17,7 +17,7 @@
 		<relativePath>../../..</relativePath>
 		<groupId>org.eclipse.gemoc.execution.concurrent.ccsljava</groupId>
 		<artifactId>org.eclipse.gemoc.execution.concurrent.ccsljava.root</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.tests</artifactId>

--- a/concurrent_addons/plugins/pom.xml
+++ b/concurrent_addons/plugins/pom.xml
@@ -12,7 +12,7 @@
 		<relativePath>../..</relativePath>
 		<groupId>org.eclipse.gemoc.gemoc-studio-execution-moccml.bundle</groupId>
 		<artifactId>org.eclipse.gemoc.execution.concurrent.ccsljava.root</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.gemoc.concurrent_addons.plugins</artifactId>

--- a/examples/moccmlSigPML/modeling_workbench/org.eclipse.gemoc.example.moccmlsigpml.simple_example/launch/debug simple.launch
+++ b/examples/moccmlSigPML/modeling_workbench/org.eclipse.gemoc.example.moccmlsigpml.simple_example/launch/debug simple.launch
@@ -4,12 +4,13 @@
     <booleanAttribute key="Do Exhaustive Simulation" value="false"/>
     <intAttribute key="GEMOC_ANIMATE_DELAY" value="0"/>
     <stringAttribute key="GEMOC_LAUNCH_INITIALIZATION_ARGUMENTS" value=""/>
-    <stringAttribute key="GEMOC_LAUNCH_INITIALIZATION_METHOD" value="org.eclipse.gemoc.example.moccmlsigpml.k3dsa.SystemAspect.initializeModel"/>
+    <stringAttribute key="GEMOC_LAUNCH_INITIALIZATION_METHOD" value=""/>
     <stringAttribute key="GEMOC_LAUNCH_SELECTED_DECIDER" value="Step by step user decider"/>
     <stringAttribute key="GEMOC_LAUNCH_SELECTED_LANGUAGE" value="xSigPML"/>
     <booleanAttribute key="General" value="false"/>
     <booleanAttribute key="Generic MultiDimensional Data Trace" value="false"/>
     <booleanAttribute key="Generic MultiDimensional Trace" value="false"/>
+    <stringAttribute key="MOCCML_SCENARIO_PATH" value=""/>
     <booleanAttribute key="MultiBranch Reflective Trace" value="true"/>
     <stringAttribute key="Resource" value="/org.eclipse.gemoc.example.moccmlsigpml.simple_example/Simple.sigpml"/>
     <stringAttribute key="TIMEMODEL_PATH" value=""/>
@@ -17,4 +18,7 @@
     <stringAttribute key="airdResource" value="/org.eclipse.gemoc.example.moccmlsigpml.simple_example/Simple.aird"/>
     <booleanAttribute key="fsm MultiDimensional Trace" value="false"/>
     <booleanAttribute key="org.eclipse.gemoc.trace.gemoc.addon_booleanOption" value="false"/>
+    <booleanAttribute key="org.eclipse.gemoc.trace.gemoc.addon_equivClassComputing_booleanOption" value="false"/>
+    <booleanAttribute key="org.eclipse.gemoc.trace.gemoc.addon_saveTraceOnEngineStop_booleanOption" value="true"/>
+    <booleanAttribute key="org.eclipse.gemoc.trace.gemoc.addon_saveTraceOnStep_booleanOption" value="false"/>
 </launchConfiguration>

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.design/pom.xml
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.design/pom.xml
@@ -19,13 +19,13 @@
 	<parent>
 		<groupId>org.gemoc.sample.robotml</groupId>
 		<artifactId>org.gemoc.sample.robotml.root</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 		<relativePath>../../../RobotML/Language/org.gemoc.sample.robotml.root</relativePath>
 	</parent>
 
 	<artifactId>org.gemoc.sample.tfsm.design</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.5.0-SNAPSHOT</version>
 
 	
 </project>

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.k3dsa/pom.xml
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.k3dsa/pom.xml
@@ -19,13 +19,13 @@
 	<parent>
 		<groupId>org.gemoc.sample.tfsm.raspberry</groupId>
 		<artifactId>org.gemoc.sample.tfsm.raspberry.root</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 		<relativePath>../../modeling_workbench/org.gemoc.sample.tfsm.raspberry.root</relativePath>
 	</parent>
 
 	<artifactId>org.eclipse.gemoc.example.moccml.tfsm.k3dsa</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.5.0-SNAPSHOT</version>
 
 	
 </project>

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.moc.lib/pom.xml
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.moc.lib/pom.xml
@@ -19,13 +19,13 @@
 	<parent>
 		<groupId>org.gemoc.sample.robotml</groupId>
 		<artifactId>org.gemoc.sample.robotml.root</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 		<relativePath>../../../RobotML/Language/org.gemoc.sample.robotml.root</relativePath>
 	</parent>
 
 	<artifactId>org.gemoc.sample.tfsm.concurrent.moc.lib</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.5.0-SNAPSHOT</version>
 
 	
 </project>

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.model/pom.xml
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.model/pom.xml
@@ -19,13 +19,13 @@
 	<parent>
 		<groupId>org.gemoc.sample.tfsm.raspberry</groupId>
 		<artifactId>org.gemoc.sample.tfsm.raspberry.root</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 		<relativePath>../../modeling_workbench/org.gemoc.sample.tfsm.raspberry.root</relativePath>
 	</parent>
 
 	<artifactId>org.gemoc.sample.tfsm.model</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>3.4.0-SNAPSHOT</version>
+	<version>3.5.0-SNAPSHOT</version>
 
 	
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,13 +4,13 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.eclipse.gemoc.gemoc-studio-execution-moccml.bundle</groupId>
     <artifactId>org.eclipse.gemoc.execution.concurrent.ccsljava.root</artifactId>
-    <version>3.4.0-SNAPSHOT</version>
+    <version>3.5.0-SNAPSHOT</version>
     <packaging>pom</packaging>  
     
     <parent>
 		<groupId>org.eclipse.gemoc.gemoc-studio</groupId>
 		<artifactId>gemoc_studio-eclipse-bom</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 		<relativePath>../gemoc-studio/gemoc_studio/plugins/gemoc_studio-eclipse-bom</relativePath>
 	</parent>
 	  

--- a/releng/org.eclipse.gemoc.concurrent_addons.feature/feature.xml
+++ b/releng/org.eclipse.gemoc.concurrent_addons.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.gemoc.concurrent_addons.feature"
       label="GEMOC Concurrent Addons and Views"
-      version="3.4.0.qualifier"
+      version="3.5.0.qualifier"
       provider-name="%providerName"
       image="gemocstudio32.png">
 

--- a/releng/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.feature/feature.xml
+++ b/releng/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.gemoc.execution.concurrent.ccsljavaengine.feature"
       label="GEMOC Execution Engine CCSL Java Runtime"
-      version="3.4.0.qualifier"
+      version="3.5.0.qualifier"
       provider-name="%providerName"
       image="gemocstudio32.png">
 

--- a/releng/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.ui.feature/feature.xml
+++ b/releng/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.ui.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.gemoc.execution.concurrent.ccsljavaengine.ui.feature"
       label="GEMOC Execution Engine CCSL Java Runtime UI"
-      version="3.4.0.qualifier"
+      version="3.5.0.qualifier"
       provider-name="%providerName"
       image="gemocstudio32.png">
 

--- a/releng/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.feature/feature.xml
+++ b/releng/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.feature"
       label="GEMOC Execution Engine CCSL Java"
-      version="3.4.0.qualifier"
+      version="3.5.0.qualifier"
       provider-name="%providerName"
       image="gemocstudio32.png">
 

--- a/releng/org.eclipse.gemoc.execution.moccml.feature/feature.xml
+++ b/releng/org.eclipse.gemoc.execution.moccml.feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.gemoc.execution.moccml.feature"
       label="GEMOC ExecutionMOCCML"
-      version="3.4.0.qualifier"
+      version="3.5.0.qualifier"
       provider-name="%providerName"
       image="gemocstudio32.png">
 

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.eclipse.gemoc.gemoc-studio-execution-moccml.bundle</groupId>
     	<artifactId>org.eclipse.gemoc.execution.concurrent.ccsljava.root</artifactId>
-        <version>3.4.0-SNAPSHOT</version>
+        <version>3.5.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
 	</parent>
 	

--- a/testScenarioLang/pom.xml
+++ b/testScenarioLang/pom.xml
@@ -12,7 +12,7 @@
 		<relativePath>..</relativePath>
 		<groupId>org.eclipse.gemoc.gemoc-studio-execution-moccml.bundle</groupId>
 		<artifactId>org.eclipse.gemoc.execution.concurrent.ccsljava.root</artifactId>
-		<version>3.4.0-SNAPSHOT</version>
+		<version>3.5.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.gemoc.execution.concurrent.ccsljava.testscenariolang.plugins</artifactId>


### PR DESCRIPTION
## Description

Bump GEMOC Studio version to 3.5.0

## Companion Pull Requests

 - https://github.com/eclipse/gemoc-studio/pull/254
 - https://github.com/eclipse/gemoc-studio-modeldebugging/pull/212
 - https://github.com/eclipse/gemoc-studio-moccml/pull/22
 - https://github.com/eclipse/gemoc-studio-execution-ale/pull/51
 - https://github.com/eclipse/gemoc-studio-execution-java/pull/22
 