### PR TITLE
Use tpd for defining target platform

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,17 +39,7 @@
 
   	<!-- List of P2 repositories of external tool used to build the components -->
   	<!--  must NOT include the repositories of the tools included in the Studio has it has its own complementary list -->
-        <repository>
-            <id>Eclipse release</id>
-            <layout>p2</layout>
-            <url>${eclipse.release.p2.url}</url>
-        </repository>
-        <repository>
-            <id>timesquare</id>
-            <layout>p2</layout>
-            <!-- <url>http://www.i3s.unice.fr/~deantoni/photon/</url> -->
-            <url>${timesquare.p2.url}</url>
-        </repository>
+        <!-- list only the repo not present in the target platform -->
 		<repository>
             <id>K3</id>
             <layout>p2</layout>
@@ -65,23 +55,20 @@
             <layout>p2</layout>
             <url>http://download.eclipse.org/gemoc/updates/nightly/</url>
         </repository> -->
-        
-        <repository> <!-- indirectly, required by the test that indirectly grabs sequential_addon.stategraph that depends on it -->
+        <!-- indirectly, required by the test that indirectly grabs sequential_addon.stategraph that depends on it -->
+        <!--<repository> 
             <id>elk</id>
             <layout>p2</layout>
             <url>${elk.p2.url}</url>
-        </repository>
-		<repository> <!-- used in some tests -->
+        </repository>-->
+		<!-- used in some tests -->
+		<!--<repository> 
             <id>Groovy4Eclipse</id>
             <layout>p2</layout>
             <url>http://dist.springsource.org/snapshot/GRECLIPSE/e4.6/</url>
-        </repository>
+        </repository>-->
         
-        <repository> <!-- used in some tests -->
-            <id>AspectJ</id>
-            <layout>p2</layout>
-            <url>${aspectJ.p2.url}</url>
-        </repository>
+
     </repositories>
 
 
@@ -178,6 +165,14 @@
 				<artifactId>target-platform-configuration</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>
+					<target>
+                        <artifact>
+                            <groupId>org.eclipse.gemoc.gemoc-studio.bundle</groupId>
+                            <artifactId>org.eclipse.gemoc.gemoc_studio.targetplatform</artifactId>
+                            <version>3.5.0-SNAPSHOT</version>
+                            <classifier>gemoc_studio</classifier>
+                        </artifact>
+                    </target>
 					<!-- environments that will be built -->
 					<environments>
 						<environment>


### PR DESCRIPTION
## Description
This PR changes the way the external update sites are imported in the build.
Instead of using maven repository like:
```
	<repositories>
		<repository>
			<id>Eclipse release</id>
			<layout>p2</layout>
			<url>${eclipse.release.p2.url}</url>
		</repository>
```
It uses a tpd description file in order to generate a targetplatform file.
This tpd allows to not specify precisely the version of the imported unit while helping to control where they come from.

A readme file explains how to update the target file from the tpd (in `gemoc_studio/releng/org.eclipse.gemoc.gemoc_studio.targetplatform`)

NOTE: the use of the tpd is partial: the K3 and melange updatesite currently cannot be integrated in the target because these tools depends on gemoc.dsl that is actually build by GEMOC. This creates a kind of cycle in the targetplatfomr :disappointed: . Melange an K3 as thus still using the maven repository descriptor.

Additionally, the integration tests now explicitly use the gemoc product and target (this fix the javafx error preventing from opening the multidimentional view in the tests)

 :disappointed: I was expecting a speed up in the build (https://github.com/eclipse/gemoc-studio/issues/233) but, apparently, the newer version of tycho are optimized enough and there is no visible speed change.
 
## Contribution to issues

Contribute to https://github.com/eclipse/gemoc-studio/issues/233


## Companion Pull Requests

 - https://github.com/eclipse/gemoc-studio/pull/259
 - https://github.com/eclipse/gemoc-studio-modeldebugging/pull/216
 - https://github.com/eclipse/gemoc-studio-execution-moccml/pull/66
 - https://github.com/eclipse/gemoc-studio-moccml/pull/24
 - https://github.com/eclipse/gemoc-studio-execution-ale/pull/53
 - https://github.com/eclipse/gemoc-studio-execution-java/pull/24
