### PR TITLE
Bump to Eclipse 2022-06

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
 	<extension>
 		<groupId>org.eclipse.tycho</groupId>
 		<artifactId>tycho-build</artifactId>
-		<version>2.7.0</version>
+		<version>2.7.3</version>
 	</extension>
 </extensions>

--- a/ccsljava_engine/plugins/pom.xml
+++ b/ccsljava_engine/plugins/pom.xml
@@ -12,7 +12,7 @@
 		<relativePath>../..</relativePath>
 		<groupId>org.eclipse.gemoc.gemoc-studio-execution-moccml.bundle</groupId>
 		<artifactId>org.eclipse.gemoc.execution.concurrent.ccsljava.root</artifactId>
-		<version>3.5.0-SNAPSHOT</version>
+		<version>3.6.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.gemoc.execution.concurrent.ccsljavaengine.plugins</artifactId>

--- a/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.moccml.example.deployer/META-INF/MANIFEST.MF
+++ b/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.moccml.example.deployer/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: GEMOC MoCCML Engine example deployer
 Bundle-SymbolicName: org.eclipse.gemoc.execution.moccml.example.deployer;singleton:=true
-Bundle-Version: 3.5.0.qualifier
+Bundle-Version: 3.6.0.qualifier
 Automatic-Module-Name: org.eclipse.gemoc.ale.language.sample.deployer
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.gemoc.sequential.language.wb.sample.deployer,

--- a/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.moccml.example.deployer/pom.xml
+++ b/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.moccml.example.deployer/pom.xml
@@ -18,7 +18,7 @@
 		<relativePath>../../..</relativePath>
 		<groupId>org.eclipse.gemoc.gemoc-studio-execution-moccml.bundle</groupId>
 		<artifactId>org.eclipse.gemoc.execution.concurrent.ccsljava.root</artifactId>
-		<version>3.5.0-SNAPSHOT</version>
+		<version>3.6.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.gemoc.execution.moccml.example.deployer</artifactId>

--- a/ccsljava_xdsml/plugins/pom.xml
+++ b/ccsljava_xdsml/plugins/pom.xml
@@ -12,7 +12,7 @@
 		<relativePath>../..</relativePath>
 		<groupId>org.eclipse.gemoc.gemoc-studio-execution-moccml.bundle</groupId>
 		<artifactId>org.eclipse.gemoc.execution.concurrent.ccsljava.root</artifactId>
-		<version>3.5.0-SNAPSHOT</version>
+		<version>3.6.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.plugins</artifactId>

--- a/ccsljava_xdsml/tests/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.tests/pom.xml
+++ b/ccsljava_xdsml/tests/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.tests/pom.xml
@@ -17,7 +17,7 @@
 		<relativePath>../../..</relativePath>
 		<groupId>org.eclipse.gemoc.execution.concurrent.ccsljava</groupId>
 		<artifactId>org.eclipse.gemoc.execution.concurrent.ccsljava.root</artifactId>
-		<version>3.5.0-SNAPSHOT</version>
+		<version>3.6.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.tests</artifactId>

--- a/concurrent_addons/plugins/pom.xml
+++ b/concurrent_addons/plugins/pom.xml
@@ -12,7 +12,7 @@
 		<relativePath>../..</relativePath>
 		<groupId>org.eclipse.gemoc.gemoc-studio-execution-moccml.bundle</groupId>
 		<artifactId>org.eclipse.gemoc.execution.concurrent.ccsljava.root</artifactId>
-		<version>3.5.0-SNAPSHOT</version>
+		<version>3.6.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.gemoc.concurrent_addons.plugins</artifactId>

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.design/pom.xml
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.design/pom.xml
@@ -19,13 +19,13 @@
 	<parent>
 		<groupId>org.gemoc.sample.robotml</groupId>
 		<artifactId>org.gemoc.sample.robotml.root</artifactId>
-		<version>3.5.0-SNAPSHOT</version>
+		<version>3.6.0-SNAPSHOT</version>
 		<relativePath>../../../RobotML/Language/org.gemoc.sample.robotml.root</relativePath>
 	</parent>
 
 	<artifactId>org.gemoc.sample.tfsm.design</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>3.5.0-SNAPSHOT</version>
+	<version>3.6.0-SNAPSHOT</version>
 
 	
 </project>

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.k3dsa/pom.xml
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.k3dsa/pom.xml
@@ -19,13 +19,13 @@
 	<parent>
 		<groupId>org.gemoc.sample.tfsm.raspberry</groupId>
 		<artifactId>org.gemoc.sample.tfsm.raspberry.root</artifactId>
-		<version>3.5.0-SNAPSHOT</version>
+		<version>3.6.0-SNAPSHOT</version>
 		<relativePath>../../modeling_workbench/org.gemoc.sample.tfsm.raspberry.root</relativePath>
 	</parent>
 
 	<artifactId>org.eclipse.gemoc.example.moccml.tfsm.k3dsa</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>3.5.0-SNAPSHOT</version>
+	<version>3.6.0-SNAPSHOT</version>
 
 	
 </project>

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.moc.lib/pom.xml
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.moc.lib/pom.xml
@@ -19,13 +19,13 @@
 	<parent>
 		<groupId>org.gemoc.sample.robotml</groupId>
 		<artifactId>org.gemoc.sample.robotml.root</artifactId>
-		<version>3.5.0-SNAPSHOT</version>
+		<version>3.6.0-SNAPSHOT</version>
 		<relativePath>../../../RobotML/Language/org.gemoc.sample.robotml.root</relativePath>
 	</parent>
 
 	<artifactId>org.gemoc.sample.tfsm.concurrent.moc.lib</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>3.5.0-SNAPSHOT</version>
+	<version>3.6.0-SNAPSHOT</version>
 
 	
 </project>

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.model/pom.xml
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.model/pom.xml
@@ -19,13 +19,13 @@
 	<parent>
 		<groupId>org.gemoc.sample.tfsm.raspberry</groupId>
 		<artifactId>org.gemoc.sample.tfsm.raspberry.root</artifactId>
-		<version>3.5.0-SNAPSHOT</version>
+		<version>3.6.0-SNAPSHOT</version>
 		<relativePath>../../modeling_workbench/org.gemoc.sample.tfsm.raspberry.root</relativePath>
 	</parent>
 
 	<artifactId>org.gemoc.sample.tfsm.model</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>3.5.0-SNAPSHOT</version>
+	<version>3.6.0-SNAPSHOT</version>
 
 	
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,13 +4,13 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.eclipse.gemoc.gemoc-studio-execution-moccml.bundle</groupId>
     <artifactId>org.eclipse.gemoc.execution.concurrent.ccsljava.root</artifactId>
-    <version>3.5.0-SNAPSHOT</version>
+    <version>3.6.0-SNAPSHOT</version>
     <packaging>pom</packaging>  
     
     <parent>
 		<groupId>org.eclipse.gemoc.gemoc-studio</groupId>
 		<artifactId>gemoc_studio-eclipse-bom</artifactId>
-		<version>3.5.0-SNAPSHOT</version>
+		<version>3.6.0-SNAPSHOT</version>
 		<relativePath>../gemoc-studio/gemoc_studio/plugins/gemoc_studio-eclipse-bom</relativePath>
 	</parent>
 	  
@@ -169,7 +169,7 @@
                         <artifact>
                             <groupId>org.eclipse.gemoc.gemoc-studio.bundle</groupId>
                             <artifactId>org.eclipse.gemoc.gemoc_studio.targetplatform</artifactId>
-                            <version>3.5.0-SNAPSHOT</version>
+                            <version>3.6.0-SNAPSHOT</version>
                             <classifier>gemoc_studio</classifier>
                         </artifact>
                     </target>

--- a/releng/org.eclipse.gemoc.concurrent_addons.feature/feature.xml
+++ b/releng/org.eclipse.gemoc.concurrent_addons.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.gemoc.concurrent_addons.feature"
       label="GEMOC Concurrent Addons and Views"
-      version="3.5.0.qualifier"
+      version="3.6.0.qualifier"
       provider-name="%providerName"
       image="gemocstudio32.png">
 

--- a/releng/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.feature/feature.xml
+++ b/releng/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.gemoc.execution.concurrent.ccsljavaengine.feature"
       label="GEMOC Execution Engine CCSL Java Runtime"
-      version="3.5.0.qualifier"
+      version="3.6.0.qualifier"
       provider-name="%providerName"
       image="gemocstudio32.png">
 

--- a/releng/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.ui.feature/feature.xml
+++ b/releng/org.eclipse.gemoc.execution.concurrent.ccsljavaengine.ui.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.gemoc.execution.concurrent.ccsljavaengine.ui.feature"
       label="GEMOC Execution Engine CCSL Java Runtime UI"
-      version="3.5.0.qualifier"
+      version="3.6.0.qualifier"
       provider-name="%providerName"
       image="gemocstudio32.png">
 

--- a/releng/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.feature/feature.xml
+++ b/releng/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.feature"
       label="GEMOC Execution Engine CCSL Java"
-      version="3.5.0.qualifier"
+      version="3.6.0.qualifier"
       provider-name="%providerName"
       image="gemocstudio32.png">
 

--- a/releng/org.eclipse.gemoc.execution.moccml.feature/feature.xml
+++ b/releng/org.eclipse.gemoc.execution.moccml.feature/feature.xml
@@ -12,7 +12,7 @@
 <feature
       id="org.eclipse.gemoc.execution.moccml.feature"
       label="GEMOC ExecutionMOCCML"
-      version="3.5.0.qualifier"
+      version="3.6.0.qualifier"
       provider-name="%providerName"
       image="gemocstudio32.png">
 

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.eclipse.gemoc.gemoc-studio-execution-moccml.bundle</groupId>
     	<artifactId>org.eclipse.gemoc.execution.concurrent.ccsljava.root</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.6.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
 	</parent>
 	

--- a/testScenarioLang/org.eclipse.gemoc.execution.moccml.testscenariolang.xtext/META-INF/MANIFEST.MF
+++ b/testScenarioLang/org.eclipse.gemoc.execution.moccml.testscenariolang.xtext/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.emf;bundle-version="2.6.0",
  org.eclipse.xtext;visibility:=reexport,
  org.eclipse.xtext.common.types,
- org.eclipse.xtext.generator;resolution:=optional,
+ org.eclipse.xtext.xtext.generator;resolution:=optional,
  org.eclipse.emf.codegen.ecore;resolution:=optional,
  org.eclipse.emf.mwe.utils;resolution:=optional,
  org.eclipse.emf.mwe2.launch;resolution:=optional,

--- a/testScenarioLang/pom.xml
+++ b/testScenarioLang/pom.xml
@@ -12,7 +12,7 @@
 		<relativePath>..</relativePath>
 		<groupId>org.eclipse.gemoc.gemoc-studio-execution-moccml.bundle</groupId>
 		<artifactId>org.eclipse.gemoc.execution.concurrent.ccsljava.root</artifactId>
-		<version>3.5.0-SNAPSHOT</version>
+		<version>3.6.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.gemoc.execution.concurrent.ccsljava.testscenariolang.plugins</artifactId>


### PR DESCRIPTION
## Description

Bump Eclipse base version to 2022-06 and its default version of its components
and update code to follow API changes.

Bump GEMOC studio version to 3.6.0

## Changes

- bump to tycho 2.7.3
- bump to newer version of Melange
- new splash screen
- adapt code to use xtext 2.27, remove some deprecated code, however the studio still include the `org.eclipse.xtext.generator` feature that is deprecated
- adapt code for use of Sirius 7.0.1
- some improvement in the system tests
 
## Contribution to issues

Contributes to https://github.com/eclipse/gemoc-studio/issues/270

## Companion Pull Requests

<!-- optional, indicate if this PR must be accepted in conjunction with some PR in other GEMOC github repositories in order to provide a working Studio-->
<!-- you may have to edit this PR after submitting it in order to get all cross references between the PRs -->

- PR https://github.com/eclipse/gemoc-studio/pull/273
- PR https://github.com/eclipse/gemoc-studio-modeldebugging/pull/222
- PR https://github.com/eclipse/gemoc-studio-execution-ale/pull/55
- PR https://github.com/eclipse/gemoc-studio-execution-java/pull/27
- PR https://github.com/eclipse/gemoc-studio-moccml/pull/26