### PR TITLE
Bump to version of k3 including StepCommand return null fix

### DIFF
--- a/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine/src/org/eclipse/gemoc/execution/concurrent/ccsljavaengine/dse/ASynchroneExecution.java
+++ b/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine/src/org/eclipse/gemoc/execution/concurrent/ccsljavaengine/dse/ASynchroneExecution.java
@@ -13,7 +13,7 @@ package org.eclipse.gemoc.execution.concurrent.ccsljavaengine.dse;
 
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.Optional;
+import java.util.List;
 import java.util.Map.Entry;
 import java.util.function.Consumer;
 
@@ -39,11 +39,11 @@ public class ASynchroneExecution extends OperationExecution {
 	private IMoccmlMSEStateController _clockController;
 	private HashMap<Force, When> _forces;
 	private Consumer<Step<?>> beforeStep;
-	private Consumer<Optional<Object>> afterStep;
+	private Consumer<List<Object>> afterStep;
 
 	public ASynchroneExecution(SmallStep<?> smallStep, Collection<When> whenStatements,
 			IMoccmlMSEStateController clockController, AbstractConcurrentExecutionEngine engine, Consumer<Step<?>> beforeStep,
-			Consumer<Optional<Object>> afterStep) {
+			Consumer<List<Object>> afterStep) {
 		super(smallStep, engine, beforeStep, afterStep);
 		this.beforeStep = beforeStep;
 		this.afterStep = afterStep;

--- a/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine/src/org/eclipse/gemoc/execution/concurrent/ccsljavaengine/dse/OperationExecution.java
+++ b/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine/src/org/eclipse/gemoc/execution/concurrent/ccsljavaengine/dse/OperationExecution.java
@@ -11,7 +11,7 @@
  *******************************************************************************/
 package org.eclipse.gemoc.execution.concurrent.ccsljavaengine.dse;
 
-import java.util.Optional;
+import java.util.List;
 import java.util.function.Consumer;
 
 import org.eclipse.gemoc.execution.concurrent.ccsljavaengine.commons.MoccmlModelExecutionContext;
@@ -26,10 +26,10 @@ public abstract class OperationExecution {
 	private AbstractConcurrentExecutionEngine _engine;
 	private Object _result;
 	private Consumer<Step<?>> beforeStepCallback;
-	private Consumer<Optional<Object>> afterStepCallback;
+	private Consumer<List<Object>> afterStepCallback;
 
 	protected OperationExecution(SmallStep<?> smallStep, AbstractConcurrentExecutionEngine engine,
-			Consumer<Step<?>> beforeStepCallback, Consumer<Optional<Object>> afterStepCallback) {
+			Consumer<Step<?>> beforeStepCallback, Consumer<List<Object>> afterStepCallback) {
 		this.smallStep = smallStep;
 		_engine = engine;
 		this.beforeStepCallback = beforeStepCallback;
@@ -40,7 +40,7 @@ public abstract class OperationExecution {
 		beforeStepCallback.accept(s);
 	}
 
-	protected void afterStepCallback(Optional<Object> returnValue) {
+	protected void afterStepCallback(List<Object> returnValue) {
 		afterStepCallback.accept(returnValue);
 	}
 

--- a/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine/src/org/eclipse/gemoc/execution/concurrent/ccsljavaengine/dse/SynchroneExecution.java
+++ b/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine/src/org/eclipse/gemoc/execution/concurrent/ccsljavaengine/dse/SynchroneExecution.java
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.eclipse.gemoc.execution.concurrent.ccsljavaengine.dse;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 
@@ -22,8 +24,8 @@ import org.eclipse.gemoc.trace.commons.model.trace.Step;
 
 public class SynchroneExecution extends OperationExecution {
 
-	public SynchroneExecution(SmallStep<?> smallStep, AbstractConcurrentExecutionEngine engine, Consumer<Step<?>> beforeStep,
-			Consumer<Optional<Object>> afterStep) {
+	public SynchroneExecution(SmallStep<?> smallStep, AbstractConcurrentExecutionEngine engine,
+			Consumer<Step<?>> beforeStep, Consumer<List<Object>> afterStep) {
 		super(smallStep, engine, beforeStep, afterStep);
 	}
 
@@ -38,7 +40,7 @@ public class SynchroneExecution extends OperationExecution {
 		} catch (InterruptedException e) {
 			Activator.getDefault().error("Exception received " + e.getMessage(), e);
 		}
-		afterStepCallback(Optional.of(res));
+		afterStepCallback(Collections.singletonList(res));
 	}
 
 	/**

--- a/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine/src/org/eclipse/gemoc/execution/concurrent/ccsljavaengine/engine/MoccmlExecutionEngine.java
+++ b/ccsljava_engine/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaengine/src/org/eclipse/gemoc/execution/concurrent/ccsljavaengine/engine/MoccmlExecutionEngine.java
@@ -18,7 +18,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -162,10 +161,8 @@ public class MoccmlExecutionEngine extends
 		synchronized (_futureActionsLock) {
 			ArrayList<IMoccmlFutureAction> actionsToRemove = new ArrayList<IMoccmlFutureAction>();
 			for (IMoccmlFutureAction action : _futureActions) {
-				if (((ModelSpecificEvent)_mseStateController.getFeedBackModelResource().getEObject(action.getTriggeringMSEURI())).getName()
-						.compareTo(
-								mse.getName()
-						)==0) {
+				if (((ModelSpecificEvent) _mseStateController.getFeedBackModelResource()
+						.getEObject(action.getTriggeringMSEURI())).getName().compareTo(mse.getName()) == 0) {
 					actionsToRemove.add(action);
 					action.perform(_mseStateController);
 				}
@@ -193,7 +190,7 @@ public class MoccmlExecutionEngine extends
 			Consumer<Step<?>> beforeStep = s -> {
 				beforeExecutionStep(s);
 			};
-			Consumer<Optional<Object>> afterStep = (o) -> {
+			Consumer<List<Object>> afterStep = (o) -> {
 				afterExecutionStep(o);
 			};
 			if (whenStatements.size() == 0) {
@@ -219,8 +216,8 @@ public class MoccmlExecutionEngine extends
 			Activator.getDefault().debug("No more LogicalStep to run");
 //			stop();
 		} else {
-			//scenario mangement
-			if(moccmlScenario != null) {
+			// scenario mangement
+			if (moccmlScenario != null) {
 				applyScenarioEffect();
 			}
 			try {
@@ -241,48 +238,51 @@ public class MoccmlExecutionEngine extends
 			} catch (Throwable t) {
 				throw new RuntimeException(t);
 			}
-			
+
 		}
 	}
 
 	private void applyScenarioEffect() {
 		Statement currentScenarioStatement = scenarioStatementSequence.get(indexInScenarioStatementSequence);
 		dealWithRwRCallStatement(currentScenarioStatement);
-		if(currentScenarioStatement instanceof MseStatement) {
+		if (currentScenarioStatement instanceof MseStatement) {
 			HashSet<Clock> clockToForceAbsent = new HashSet<Clock>(clockUsedInScenario);
 			EList<Clock> statementClocks = ((MseStatement) currentScenarioStatement).getClocks();
-			for(Clock toRemove : statementClocks) {
+			for (Clock toRemove : statementClocks) {
 				clockToForceAbsent.remove(toRemove);
 			}
-			for(Clock c : clockToForceAbsent) {
+			for (Clock c : clockToForceAbsent) {
 				EventOccurrence occ = getEventOccurrenceFromClock(c);
 				_solver.forbidEventOccurrence(occ);
 			}
-			if(statementClocks.size() > 1) {
+			if (statementClocks.size() > 1) {
 				Clock oneClock = statementClocks.get(0);
 				EventOccurrence oneClockOcc = getEventOccurrenceFromClock(oneClock);
-				for(int i = 1; i < statementClocks.size(); i++) {
+				for (int i = 1; i < statementClocks.size(); i++) {
 					EventOccurrence anotherClockOcc = getEventOccurrenceFromClock(statementClocks.get(i));
 					_solver.addClockCoincidence(oneClockOcc, anotherClockOcc);
 				}
 			}
 			_possibleLogicalSteps = computePossibleLogicalSteps();
 			if (!_solver.hasSolution()) {
-				Activator.getDefault().error("The scenario violates the semantics at step "+indexInScenarioStatementSequence+". One of these clock cannot be absent: "+clockToForceAbsent);
+				Activator.getDefault()
+						.error("The scenario violates the semantics at step " + indexInScenarioStatementSequence
+								+ ". One of these clock cannot be absent: " + clockToForceAbsent);
 //						stop();
-			} 
-			//try to force presence of currentStatement but if not possible it does not mean it will not be possible in a future step so we have to revert
-			for(Clock toForce : statementClocks) {
+			}
+			// try to force presence of currentStatement but if not possible it does not
+			// mean it will not be possible in a future step so we have to revert
+			for (Clock toForce : statementClocks) {
 				EventOccurrence occ = getEventOccurrenceFromClock(toForce);
 				_solver.forceEventOccurrence(occ);
 			}
-			if(!_solver.hasSolution()) {
+			if (!_solver.hasSolution()) {
 				_solver.revertForceClockEffect();
-				for(Clock c : clockToForceAbsent) {
+				for (Clock c : clockToForceAbsent) {
 					EventOccurrence occ = getEventOccurrenceFromClock(c);
 					_solver.forbidEventOccurrence(occ);
 				}
-				
+
 			}
 			_possibleLogicalSteps = computePossibleLogicalSteps();
 			notifyProposedLogicalStepsChanged();
@@ -298,8 +298,7 @@ public class MoccmlExecutionEngine extends
 		occ.setReferedElement(mer);
 		return occ;
 	}
-	
-	
+
 	public void recomputePossibleLogicalSteps() {
 		getSolver().revertForceClockEffect();
 		updatePossibleLogicalSteps();
@@ -328,7 +327,7 @@ public class MoccmlExecutionEngine extends
 		Resource resFeedbackModel = executionContext.setUpFeedbackModel();
 		_mseStateController.setFeedBackModelResource(resFeedbackModel);
 
-		if(executionContext.hasARegisteredScenario) {
+		if (executionContext.hasARegisteredScenario) {
 //			URI scenarioModelPlatformURI = URI.createPlatformResourceURI(
 //						concurrentExecutionContext.getMoccmlscenarioModelPath(), true);
 //			ResourceSet resourceSet = new ResourceSetImpl();
@@ -339,12 +338,13 @@ public class MoccmlExecutionEngine extends
 			indexInScenarioStatementSequence = 0;
 			clockUsedInScenario = new HashSet<Clock>();
 
-			for(Statement s : moccmlScenario.getStatementSequence().stream().filter(s -> s instanceof MseStatement).collect(Collectors.toList())) {
-				clockUsedInScenario.addAll(((MseStatement)s).getClocks());
+			for (Statement s : moccmlScenario.getStatementSequence().stream().filter(s -> s instanceof MseStatement)
+					.collect(Collectors.toList())) {
+				clockUsedInScenario.addAll(((MseStatement) s).getClocks());
 			}
 		}
 	}
-	
+
 	private Scenario loadTestScenarioLangification(String filename) {
 		if (filename == null || filename.isEmpty()) {
 			return null;
@@ -353,15 +353,14 @@ public class MoccmlExecutionEngine extends
 		Injector injector = TestScenarioLangActivator.getInstance().getInjector(language);
 		XtextResourceSetProvider provider = injector.getInstance(XtextResourceSetProvider.class);
 
-		XtextResourceSet resourceSet = (XtextResourceSet) provider
-				.get(findContainingProject(filename));
+		XtextResourceSet resourceSet = (XtextResourceSet) provider.get(findContainingProject(filename));
 		resourceSet.addLoadOption(XtextResource.OPTION_RESOLVE_ALL, Boolean.TRUE);
 
 		URI uri = URI.createPlatformResourceURI(filename, true);
 		XtextResource resource = (XtextResource) resourceSet.getResource(uri, true);
 		List<Diagnostic> errors = resource.getErrors();
 		if (!errors.isEmpty()) {
-			System.err.println("the moccml scenrio file contains errors: "+errors);
+			System.err.println("the moccml scenrio file contains errors: " + errors);
 			return null;
 		}
 		return (Scenario) resource.getContents().get(0);
@@ -375,25 +374,26 @@ public class MoccmlExecutionEngine extends
 		IFile file = (IFile) root.findMember(filename);
 		return (file != null ? file.getProject() : null);
 	}
-	
+
 	@Override
 	protected void doAfterLogicalStepExecution(Step<?> logicalStep) {
-	
+
 		getSolver().applyLogicalStep(logicalStep);
 		List<String> assertions = getSolver().getAssertionViolations();
-		if(assertions.size() > 0) {
+		if (assertions.size() > 0) {
 			System.err.println("###############################################\n  WARNING ! Assertion violation");
-			Activator.getDefault().error("###############################################\n  WARNING ! Assertion violation");
+			Activator.getDefault()
+					.error("###############################################\n  WARNING ! Assertion violation");
 		}
-		for(String ass : assertions) {
-			System.err.println("#    "+ ass);
-			Activator.getDefault().error("#    "+ ass);
+		for (String ass : assertions) {
+			System.err.println("#    " + ass);
+			Activator.getDefault().error("#    " + ass);
 		}
-		if(assertions.size() > 0) {
+		if (assertions.size() > 0) {
 			System.err.println("###############################################");
 			Activator.getDefault().error("###############################################");
 		}
-		if(moccmlScenario != null) {
+		if (moccmlScenario != null) {
 			manageScenario(logicalStep);
 		}
 	}
@@ -403,7 +403,8 @@ public class MoccmlExecutionEngine extends
 		if (currentScenarioStatement instanceof MseStatement) {
 			ArrayList<Clock> clocksThatTicked = new ArrayList<Clock>();
 			retrieveAllClocksFromStep(logicalStep, clocksThatTicked);
-			if (((MseStatement)currentScenarioStatement).getClocks().stream().allMatch(c -> clocksThatTicked.stream().anyMatch(c2 ->c2.getName().compareTo(c.getName()) == 0))){
+			if (((MseStatement) currentScenarioStatement).getClocks().stream().allMatch(
+					c -> clocksThatTicked.stream().anyMatch(c2 -> c2.getName().compareTo(c.getName()) == 0))) {
 				indexInScenarioStatementSequence++;
 				currentScenarioStatement = scenarioStatementSequence.get(indexInScenarioStatementSequence);
 				dealWithRwRCallStatement(currentScenarioStatement);
@@ -412,7 +413,7 @@ public class MoccmlExecutionEngine extends
 	}
 
 	private void dealWithRwRCallStatement(Statement currentScenarioStatement) {
-		while(! (currentScenarioStatement instanceof MseStatement)) {
+		while (!(currentScenarioStatement instanceof MseStatement)) {
 			RewritingRuleCallStatement rwrcallStatement = (RewritingRuleCallStatement) currentScenarioStatement;
 			ObjectVariable ov = rwrcallStatement.getObjectVariable();
 			JavaVariable javaVar = new JavaVariable(ov.getName(), ov.getType().getType().getQualifiedName());
@@ -421,15 +422,15 @@ public class MoccmlExecutionEngine extends
 			EList<Variable> params = rwrcallStatement.getParameters();
 			Object[] realParams = new Object[params.size()];
 			Class<?>[] realParamTypes = new Class<?>[params.size()];
-			for(int i = 0; i < params.size();i++) {
+			for (int i = 0; i < params.size(); i++) {
 				Variable v = params.get(i);
 				if (v instanceof EObjectRef) {
-					realParams[i]=((EObjectRef)v).getObject();
-					realParamTypes[i]=(EObject.class);//(EObjectRef)v).getObject().getClass();
+					realParams[i] = ((EObjectRef) v).getObject();
+					realParamTypes[i] = (EObject.class);// (EObjectRef)v).getObject().getClass();
 				}
 				if (v instanceof IntegerLiteral) {
-					realParams[i]=new Integer(((IntegerLiteral)v).getValue());
-					realParamTypes[i] =Integer.class;
+					realParams[i] = new Integer(((IntegerLiteral) v).getValue());
+					realParamTypes[i] = Integer.class;
 				}
 			}
 			Method m;
@@ -438,7 +439,8 @@ public class MoccmlExecutionEngine extends
 				// it is possible to get the result here !
 				Object res = m.invoke(obj, realParams);
 				System.out.println(res);
-			} catch (NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+			} catch (NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException
+					| InvocationTargetException e) {
 				// TODO Auto-generated catch block
 				e.printStackTrace();
 			}
@@ -449,31 +451,33 @@ public class MoccmlExecutionEngine extends
 
 	private void retrieveAllClocksFromStep(Step<?> logicalStep, ArrayList<Clock> clocksThatTicked) {
 		TreeIterator<EObject> it = logicalStep.eAllContents();
-		while(it.hasNext()) {
+		while (it.hasNext()) {
 			EObject eo = it.next();
 			if (eo instanceof GenericSmallStep) {
-				MSE mse = ((GenericSmallStep)eo).getMseoccurrence().getMse();
+				MSE mse = ((GenericSmallStep) eo).getMseoccurrence().getMse();
 				if (mse instanceof FeedbackMSE) {
 					EObject se = ((FeedbackMSE) mse).getFeedbackModelSpecificEvent().getSolverEvent();
 					if (se instanceof Clock) {
 						clocksThatTicked.add((Clock) se);
 					}
 				}
-				
+
 			}
 		}
 	}
-	
-	public Pair<Map<String, Boolean>, ArrayList<IMoccmlFutureAction>> saveState(){ //one map is enough since view are not used in exhaustive simulation
+
+	public Pair<Map<String, Boolean>, ArrayList<IMoccmlFutureAction>> saveState() { // one map is enough since view are
+																					// not used in exhaustive simulation
 		return Pair.of(
-				new HashMap<String, Boolean>(((DefaultMSEStateController)getExecutionContext().getExecutionPlatform().getMSEStateControllers().iterator().next())._mseNextStates),
-				new ArrayList<>(this._futureActions)
-				);
+				new HashMap<String, Boolean>(((DefaultMSEStateController) getExecutionContext().getExecutionPlatform()
+						.getMSEStateControllers().iterator().next())._mseNextStates),
+				new ArrayList<>(this._futureActions));
 	}
-	
-	public void restoreState(Pair<Map<String, Boolean>, ArrayList<IMoccmlFutureAction>> controllerStates){
+
+	public void restoreState(Pair<Map<String, Boolean>, ArrayList<IMoccmlFutureAction>> controllerStates) {
 //		((DefaultMSEStateController)getExecutionContext().getExecutionPlatform().getMSEStateControllers().iterator().next())._mseNextStates = new HashMap<String, Boolean>(controllerStates.getLeft());
-		((DefaultMSEStateController)_mseStateController)._mseNextStates = new HashMap<String, Boolean>(controllerStates.getLeft());
+		((DefaultMSEStateController) _mseStateController)._mseNextStates = new HashMap<String, Boolean>(
+				controllerStates.getLeft());
 		this._futureActions = new ArrayList<IMoccmlFutureAction>(controllerStates.getRight());
 	}
 

--- a/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.api/src/org/eclipse/gemoc/execution/concurrent/ccsljavaxdsml/api/core/AbstractConcurrentExecutionEngine.java
+++ b/ccsljava_xdsml/plugins/org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.api/src/org/eclipse/gemoc/execution/concurrent/ccsljavaxdsml/api/core/AbstractConcurrentExecutionEngine.java
@@ -1,8 +1,8 @@
 package org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.api.core;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 import org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.api.dsa.executors.CodeExecutionException;
 import org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.api.moc.DeciderException;
@@ -99,7 +99,7 @@ public abstract class AbstractConcurrentExecutionEngine<C extends AbstractConcur
 				SmallStep<?> sstep = (SmallStep<?>) step;
 				executeSmallStep(sstep);
 			}
-			afterExecutionStep(Optional.empty());
+			afterExecutionStep(Collections.emptyList());
 		}
 	}
 


### PR DESCRIPTION
## Description

Bump to the latest version of K3 that includes the support for all kind of StepCommand (ie. result being void, null or an object)

## Changes

Adapt the engine to the new return structure (ie. List)
## Companion Pull Requests


 - https://github.com/eclipse/gemoc-studio/pull/284
 - https://github.com/eclipse/gemoc-studio-modeldebugging/pull/229
 - https://github.com/eclipse/gemoc-studio-execution-ale/pull/59
 - https://github.com/eclipse/gemoc-studio-execution-java/pull/30
