### PR TITLE
Fix tfsm moccml example

### DIFF
--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.design/.classpath
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.design/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.design/.settings/org.eclipse.core.resources.prefs
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.design/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.design/META-INF/MANIFEST.MF
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.design/META-INF/MANIFEST.MF
@@ -24,7 +24,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.gemoc.example.moccml.tfsm.k3dsa;bundle-version="2.3.0",
  org.eclipse.gemoc.example.moccml.tfsm
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-ManifestVersion: 2
 Export-Package: org.eclipse.gemoc.example.moccml.tfsm.design,
  org.eclipse.gemoc.example.moccml.tfsm.design.services

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.k3dsa/META-INF/MANIFEST.MF
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.k3dsa/META-INF/MANIFEST.MF
@@ -18,9 +18,11 @@ Require-Bundle: org.eclipse.emf.ecore;bundle-version="2.9.1",
  org.aspectj.runtime,
  org.eclipse.gemoc.commons.eclipse.messagingsystem.api,
  org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.api;bundle-version="2.3.0",
- org.eclipse.gemoc.execution.concurrent.ccsljavaengine.extensions.k3;bundle-version="2.3.0"
+ org.eclipse.gemoc.execution.concurrent.ccsljavaengine.extensions.k3;bundle-version="2.3.0",
+ org.eclipse.gemoc.commons.eclipse.ui,
+ org.eclipse.ui;bundle-version="3.201.0"
 Bundle-ManifestVersion: 2
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Activator: org.eclipse.gemoc.example.moccml.tfsm.k3dsa.Activator
 Bundle-Vendor: Eclipse GEMOC Project

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.k3dsa/src/org/eclipse/gemoc/example/moccml/tfsm/k3dsa/Activator.java
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.k3dsa/src/org/eclipse/gemoc/example/moccml/tfsm/k3dsa/Activator.java
@@ -13,14 +13,14 @@ package org.eclipse.gemoc.example.moccml.tfsm.k3dsa;
 import org.eclipse.gemoc.commons.eclipse.logging.backends.DefaultLoggingBackend;
 import org.eclipse.gemoc.commons.eclipse.messagingsystem.api.MessagingSystem;
 import org.eclipse.gemoc.commons.eclipse.messagingsystem.api.MessagingSystemManager;
-import org.eclipse.gemoc.commons.eclipse.pde.GemocPlugin;
+import org.eclipse.gemoc.commons.eclipse.pde.ui.GemocUIPlugin;
 import org.osgi.framework.BundleContext;
 
 
 /**
  * The activator class controls the plug-in life cycle
  */
-public class Activator extends GemocPlugin {
+public class Activator extends GemocUIPlugin {
 
 	// The plug-in ID
 	public static final String PLUGIN_ID = "org.eclipse.gemoc.example.moccml.tfsm.k3dsa"; //$NON-NLS-1$

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.moc.dse/.classpath
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.moc.dse/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.moc.dse/.settings/org.eclipse.core.resources.prefs
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.moc.dse/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.moc.dse/.settings/org.eclipse.jdt.core.prefs
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.moc.dse/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,10 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=11

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.moc.dse/META-INF/MANIFEST.MF
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.moc.dse/META-INF/MANIFEST.MF
@@ -7,6 +7,6 @@ Bundle-Activator: org.eclipse.gemoc.example.moccml.tfsm.dse.Activator
 Require-Bundle: org.eclipse.core.runtime
 Bundle-ActivationPolicy: lazy
 Export-Package: org.eclipse.gemoc.example.moccml.tfsm.dse
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: org.eclipse.gemoc.example.moccml.tfsm.moc.dse
 Bundle-Vendor: Eclipse GEMOC Project

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.moc.lib/.classpath
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.moc.lib/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.moc.lib/.settings/org.eclipse.core.resources.prefs
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.moc.lib/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.moc.lib/.settings/org.eclipse.jdt.core.prefs
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.moc.lib/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,10 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=11

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.moc.lib/META-INF/MANIFEST.MF
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.moc.lib/META-INF/MANIFEST.MF
@@ -6,6 +6,6 @@ Bundle-Version: 2.3.0.qualifier
 Bundle-Activator: org.gemoc.sample.tfsm.concurrent.moc.lib.Activator
 Require-Bundle: org.eclipse.core.runtime
 Bundle-ActivationPolicy: lazy
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Automatic-Module-Name: org.eclipse.gemoc.example.moccml.tfsm.moc.lib
 Bundle-Vendor: Eclipse GEMOC Project

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.model.edit/.classpath
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.model.edit/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="emf-gen"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="emf-gen"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.model.edit/.settings/org.eclipse.core.resources.prefs
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.model.edit/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.model.edit/.settings/org.eclipse.jdt.core.prefs
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.model.edit/.settings/org.eclipse.jdt.core.prefs
@@ -1,5 +1,4 @@
 eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
 org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
 org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.model.edit/META-INF/MANIFEST.MF
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.model.edit/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.gemoc.example.moccml.tfsm.tfsm.provider.TfsmEditPlugin$Implementation
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.gemoc.example.moccml.tfsm.tfsm.provider
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.gemoc.example.moccml.tfsm.model;visibility:=reexport,

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.model.editor/.classpath
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.model.editor/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="emf-gen"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="emf-gen"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.model.editor/.settings/org.eclipse.core.resources.prefs
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.model.editor/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.model.editor/.settings/org.eclipse.jdt.core.prefs
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.model.editor/.settings/org.eclipse.jdt.core.prefs
@@ -1,5 +1,4 @@
 eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
 org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
 org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.model.editor/META-INF/MANIFEST.MF
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.model.editor/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-ClassPath: .
 Bundle-Activator: org.eclipse.gemoc.example.moccml.tfsm.tfsm.presentation.TfsmEditorPlugin$Implementation
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.gemoc.example.moccml.tfsm.tfsm.presentation
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources;visibility:=reexport,

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.model/.classpath
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.model/.classpath
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="emf-gen"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="emf-gen"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.model/.settings/org.eclipse.core.resources.prefs
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.model/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.model/.settings/org.eclipse.jdt.core.prefs
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.model/.settings/org.eclipse.jdt.core.prefs
@@ -1,11 +1,14 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=11

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.model/META-INF/MANIFEST.MF
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm.model/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Version: 2.3.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.eclipse.gemoc.example.moccml.tfsm.tfsm,
  org.eclipse.gemoc.example.moccml.tfsm.tfsm.impl,
  org.eclipse.gemoc.example.moccml.tfsm.tfsm.util

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm/.classpath
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm/.classpath
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="xdsml-java-gen/"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm/.settings/org.eclipse.jdt.core.prefs
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm/.settings/org.eclipse.jdt.core.prefs
@@ -1,5 +1,4 @@
 eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
 org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
 org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error

--- a/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm/META-INF/MANIFEST.MF
+++ b/examples/moccmlTFSM/language_workbench/org.eclipse.gemoc.example.moccml.tfsm/META-INF/MANIFEST.MF
@@ -30,5 +30,5 @@ Require-Bundle: org.eclipse.emf.ecore.xmi;bundle-version="2.8.0";visibility:="re
  org.eclipse.gemoc.execution.concurrent.ccsljavaxdsml.utils;bundle-version="2.3.0"
 Bundle-ActivationPolicy: lazy
 Bundle-ManifestVersion: 2
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: Eclipse GEMOC Project


### PR DESCRIPTION


## Description

Fixes the tfsm moccml example 

These changes are required due to https://github.com/eclipse/gemoc-studio-commons/pull/1

Also update some project configuration (minimum java version to java 11, project encoding UTF-8, ...)

