### PR TITLE
Bump to Eclipse 2023 06

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
 	<extension>
 		<groupId>org.eclipse.tycho</groupId>
 		<artifactId>tycho-build</artifactId>
-		<version>2.7.3</version>
+		<version>3.0.4</version>
 	</extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -92,23 +92,20 @@
 							<goal>plugin-source</goal>
 						</goals>
 					</execution>
+					<execution>
+			            <id>feature-source</id>
+			            <goals>
+			              <goal>feature-source</goal>
+			            </goals>
+			            <configuration>
+			              <excludes>
+			                <!-- provide plug-ins not containing any source code -->
+			                <!-- also possible to exclude feature-->
+			              </excludes>
+			            </configuration>
+          			</execution>
 				</executions>
 			</plugin>
-			<!-- enable source feature generation -->
-			<plugin>
-		      <groupId>org.eclipse.tycho.extras</groupId>
-		      <artifactId>tycho-source-feature-plugin</artifactId>
-		      <version>${tycho-version}</version>
-		      <executions>
-		        <execution>
-		          <id>source-feature</id>
-		          <phase>package</phase>
-		          <goals>
-		            <goal>source-feature</goal>
-		          </goals>
-		        </execution>
-		      </executions>
-		    </plugin>
 		    <plugin>
 		     <groupId>org.eclipse.tycho</groupId>
 		     <artifactId>tycho-p2-plugin</artifactId>
@@ -215,10 +212,9 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.0</version>
 				<configuration>
-					<source>11</source>
-					<target>11</target>
+					<source>17</source>
+					<target>17</target>
 					<encoding>${project.build.sourceEncoding}</encoding>
                                         <artifact>
                                             <id>org.jdom:jdom2:2.0.6</id>
@@ -237,8 +233,8 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>3.8.0</version>
 					<configuration>
-						<source>11</source>
-						<target>11</target>
+						<source>17</source>
+						<target>17</target>
 						<encoding>${project.build.sourceEncoding}</encoding>
 					</configuration>
 				</plugin>


### PR DESCRIPTION
## Description

Upgrade the base Eclipse to Eclipse 2023-06.
Applies the changes required by the new version of components (XText, Xtend, Sirius)
New minimal requirement : java 17

## Changes

<!-- more details , changed documentation sections, changed version, some details about the code changes -->
 
 - Use java 17 in the CI docker image
 - new splash screen
 - use tycho 3.0.4
 - use xtend 2.31
 - use lsp4j 0.21
 - change maven plugin for generating plantuml images
 - fix melangeK3FSM project nature
 - remove use of deprecated xtext.MergeableManifest
 
## Contribution to issues

Contribute to #298 

## Companion Pull Requests

 - https://github.com/eclipse/gemoc-studio/pull/299
 - https://github.com/eclipse/gemoc-studio-modeldebugging/pull/232
 - https://github.com/eclipse/gemoc-studio-execution-ale/pull/61
 - https://github.com/eclipse/gemoc-studio-execution-java/pull/32
 - https://github.com/eclipse/gemoc-studio-execution-moccml/pull/77
 - https://github.com/eclipse/gemoc-studio-moccml/pull/28
 - https://github.com/eclipse/gemoc-studio-commons/pull/4
